### PR TITLE
Tests fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,6 +111,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.1'
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.1.1'
 
     androidTestImplementation "com.squareup.retrofit2:retrofit-mock:2.8.1"
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:3.8.0"

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/FixedSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/FixedSessionTest.kt
@@ -47,15 +47,13 @@ class FixedSessionTest {
 
     val app = ApplicationProvider.getApplicationContext<AircastingApplication>()
 
-    val sensorsIdlingResource = CountingIdlingResource("sensors")
-
     private fun setupDagger() {
         val permissionsModule = TestPermissionsModule()
         val testAppComponent = DaggerTestAppComponent.builder()
             .appModule(AppModule(app))
             .settingsModule(TestSettingsModule())
             .permissionsModule(permissionsModule)
-            .sensorsModule(TestSensorsModule(app, sensorsIdlingResource))
+            .sensorsModule(TestSensorsModule(app))
             .mockWebServerModule(MockWebServerModule())
             .newSessionWizardModule(TestNewSessionWizardModule())
             .build()
@@ -95,16 +93,15 @@ class FixedSessionTest {
         onView(withId(R.id.fixed_session_start_card)).perform(click())
         verify(bluetoothManager).requestBluetoothPermissions();
 
-        onView(allOf(withId(R.id.turn_on_airbeam_ready_button), isDisplayed())).perform(scrollTo(), click())
+        onView(withId(R.id.turn_on_airbeam_ready_button)).perform(scrollTo(), click())
 
         onView(withText(containsString(airBeamAddress))).perform(click())
 
         onView(withId(R.id.connect_button)).perform(click())
-        IdlingRegistry.getInstance().register(sensorsIdlingResource)
+        Thread.sleep(4000)
         onView(withId(R.id.airbeam_connected_header)).check(matches(isDisplayed()))
         onView(withId(R.id.airbeam_connected_header)).perform(scrollTo())
         onView(withId(R.id.airbeam_connected_continue_button)).perform(scrollTo(), click())
-        IdlingRegistry.getInstance().unregister(sensorsIdlingResource)
 
         // replaceText is needed here to go around autocorrect...
         onView(withId(R.id.session_name_input)).perform(replaceText("Ania's fixed outdoor session"))
@@ -163,11 +160,10 @@ class FixedSessionTest {
         onView(withText(containsString(airBeamAddress))).perform(click())
 
         onView(withId(R.id.connect_button)).perform(click())
-        IdlingRegistry.getInstance().register(sensorsIdlingResource)
+        Thread.sleep(4000)
         onView(withId(R.id.airbeam_connected_header)).check(matches(isDisplayed()))
         onView(withId(R.id.airbeam_connected_header)).perform(scrollTo())
         onView(withId(R.id.airbeam_connected_continue_button)).perform(scrollTo(), click())
-        IdlingRegistry.getInstance().unregister(sensorsIdlingResource)
 
         // replaceText is needed here to go around autocorrect...
         onView(withId(R.id.session_name_input)).perform(replaceText("Ania's fixed indoor session"))
@@ -179,8 +175,8 @@ class FixedSessionTest {
         onView(withId(R.id.networks_list_header)).check(matches(not(isDisplayed())))
         onView(withId(R.id.wifi_button)).perform(click())
 
-        onView(withId(R.id.networks_list_header)).check(matches(isDisplayed()))
         onView(withId(R.id.continue_button)).perform(scrollTo())
+        onView(withId(R.id.networks_list_header)).check(matches(isDisplayed()))
 
         onView(withText(containsString(FakeFixedSessionDetailsController.TEST_WIFI_SSID))).perform(click())
         onView(withId(R.id.wifi_password_input)).perform(replaceText("secret"))

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/FixedSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/FixedSessionTest.kt
@@ -57,6 +57,7 @@ class FixedSessionTest {
             .permissionsModule(permissionsModule)
             .sensorsModule(TestSensorsModule(app, sensorsIdlingResource))
             .mockWebServerModule(MockWebServerModule())
+            .newSessionWizardModule(TestNewSessionWizardModule())
             .build()
         app.appComponent = testAppComponent
         testAppComponent.inject(this)
@@ -120,8 +121,7 @@ class FixedSessionTest {
         onView(withId(R.id.continue_button)).perform(scrollTo())
         onView(withId(R.id.networks_list_header)).check(matches(isDisplayed()))
 
-        Thread.sleep(4000)
-        onView(withText(containsString("AndroidWifi"))).perform(click())
+        onView(withText(containsString(FakeFixedSessionDetailsController.TEST_WIFI_SSID))).perform(click())
         onView(withId(R.id.wifi_password_input)).perform(replaceText("secret"))
         onView(withId(R.id.ok_button)).perform(click())
 
@@ -186,8 +186,7 @@ class FixedSessionTest {
         onView(withId(R.id.networks_list_header)).check(matches(isDisplayed()))
         onView(withId(R.id.continue_button)).perform(scrollTo())
 
-        Thread.sleep(4000)
-        onView(withText(containsString("AndroidWifi"))).perform(click())
+        onView(withText(containsString(FakeFixedSessionDetailsController.TEST_WIFI_SSID))).perform(click())
         onView(withId(R.id.wifi_password_input)).perform(replaceText("secret"))
         onView(withId(R.id.ok_button)).perform(click())
 

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/FixedSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/FixedSessionTest.kt
@@ -100,9 +100,7 @@ class FixedSessionTest {
         onView(withText(containsString(airBeamAddress))).perform(click())
 
         onView(withId(R.id.connect_button)).perform(click())
-        onView(withId(R.id.connecting_airbeam_header)).check(matches(isDisplayed()))
         IdlingRegistry.getInstance().register(sensorsIdlingResource)
-        sensorsIdlingResource.increment()
         onView(withId(R.id.airbeam_connected_header)).check(matches(isDisplayed()))
         onView(withId(R.id.airbeam_connected_header)).perform(scrollTo())
         onView(withId(R.id.airbeam_connected_continue_button)).perform(scrollTo(), click())
@@ -165,9 +163,7 @@ class FixedSessionTest {
         onView(withText(containsString(airBeamAddress))).perform(click())
 
         onView(withId(R.id.connect_button)).perform(click())
-        onView(withId(R.id.connecting_airbeam_header)).check(matches(isDisplayed()))
         IdlingRegistry.getInstance().register(sensorsIdlingResource)
-        sensorsIdlingResource.increment()
         onView(withId(R.id.airbeam_connected_header)).check(matches(isDisplayed()))
         onView(withId(R.id.airbeam_connected_header)).perform(scrollTo())
         onView(withId(R.id.airbeam_connected_continue_button)).perform(scrollTo(), click())

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
@@ -161,9 +161,6 @@ class MobileSessionTest {
         val measurementValuesRow = onView(allOf(withId(R.id.measurement_values), isDisplayed()))
         measurementValuesRow.check(matches(hasMinimumChildCount(1)))
 
-        onView(allOf(withId(R.id.recycler_sessions), isDisplayed())).perform(swipeUp())
-        onView(withId(R.id.session_actions_button)).perform(click())
-
         clickActionsButton()
         Thread.sleep(2000)
         stopSession()
@@ -174,7 +171,7 @@ class MobileSessionTest {
         onView(withId(R.id.session_tags)).check(matches(withText("tag1, tag2")));
     }
 
-    private fun clickActionsButton(retryCount: Int = 3) {
+    private fun clickActionsButton(retryCount: Int = 0) {
         if (retryCount >= 3) {
             return
         }
@@ -186,7 +183,7 @@ class MobileSessionTest {
         }
     }
 
-    private fun stopSession(retryCount: Int = 3) {
+    private fun stopSession(retryCount: Int = 0) {
         if (retryCount >= 3) {
             return
         }

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
@@ -125,7 +125,7 @@ class MobileSessionTest {
 
         clickActionsButton()
         Thread.sleep(2000)
-        stopSession()
+        onView(withId(R.id.stop_session_button)).perform(click())
 
         Thread.sleep(4000)
 
@@ -163,7 +163,7 @@ class MobileSessionTest {
 
         clickActionsButton()
         Thread.sleep(2000)
-        stopSession()
+        onView(withId(R.id.stop_session_button)).perform(click())
 
         Thread.sleep(4000)
 
@@ -180,18 +180,6 @@ class MobileSessionTest {
             onView(withId(R.id.session_actions_button)).perform(click())
         } catch(e: NoMatchingViewException) {
             clickActionsButton(retryCount + 1)
-        }
-    }
-
-    private fun stopSession(retryCount: Int = 0) {
-        if (retryCount >= 3) {
-            return
-        }
-
-        try {
-            onView(withId(R.id.stop_session_button)).perform(click())
-        } catch(e: NoMatchingViewException) {
-            stopSession(retryCount + 1)
         }
     }
 }

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
@@ -130,6 +130,8 @@ class MobileSessionTest {
         val measurementValuesRow = onView(allOf(withId(R.id.measurement_values), isDisplayed()))
         measurementValuesRow.check(matches(hasMinimumChildCount(1)))
 
+        clickActionsButton()
+        Thread.sleep(1000)
         stopSession()
 
         Thread.sleep(4000)
@@ -169,6 +171,8 @@ class MobileSessionTest {
         onView(allOf(withId(R.id.recycler_sessions), isDisplayed())).perform(swipeUp())
         onView(withId(R.id.session_actions_button)).perform(click())
 
+        clickActionsButton()
+        Thread.sleep(1000)
         stopSession()
 
         Thread.sleep(4000)
@@ -177,14 +181,24 @@ class MobileSessionTest {
         onView(withId(R.id.session_tags)).check(matches(withText("tag1, tag2")));
     }
 
-    private fun stopSession(retryCount: Int = 3) {
+    private fun clickActionsButton(retryCount: Int = 3) {
         if (retryCount >= 3) {
             return
         }
 
         try {
             onView(withId(R.id.session_actions_button)).perform(click())
-            Thread.sleep(1000)
+        } catch(e: NoMatchingViewException) {
+            clickActionsButton(retryCount + 1)
+        }
+    }
+
+    private fun stopSession(retryCount: Int = 3) {
+        if (retryCount >= 3) {
+            return
+        }
+
+        try {
             onView(withId(R.id.stop_session_button)).perform(click())
         } catch(e: NoMatchingViewException) {
             stopSession(retryCount + 1)

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
@@ -3,11 +3,9 @@ package io.lunarlogic.aircasting
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.idling.CountingIdlingResource
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
@@ -54,15 +52,13 @@ class MobileSessionTest {
 
     val app = ApplicationProvider.getApplicationContext<AircastingApplication>()
 
-    val sensorsIdlingResource = CountingIdlingResource("sensors")
-
     private fun setupDagger() {
         val permissionsModule = TestPermissionsModule()
         val testAppComponent = DaggerTestAppComponent.builder()
             .appModule(AppModule(app))
             .settingsModule(TestSettingsModule())
             .permissionsModule(permissionsModule)
-            .sensorsModule(TestSensorsModule(app, sensorsIdlingResource))
+            .sensorsModule(TestSensorsModule(app))
             .mockWebServerModule(MockWebServerModule())
             .build()
         app.appComponent = testAppComponent
@@ -108,13 +104,10 @@ class MobileSessionTest {
         onView(withText(containsString(airBeamAddress))).perform(click())
 
         onView(withId(R.id.connect_button)).perform(click())
-        onView(withId(R.id.connecting_airbeam_header)).check(matches(isDisplayed()))
-        IdlingRegistry.getInstance().register(sensorsIdlingResource)
-        sensorsIdlingResource.increment()
+        Thread.sleep(4000)
         onView(withId(R.id.airbeam_connected_header)).check(matches(isDisplayed()))
         onView(withId(R.id.airbeam_connected_header)).perform(scrollTo())
         onView(withId(R.id.airbeam_connected_continue_button)).perform(scrollTo(), click())
-        IdlingRegistry.getInstance().unregister(sensorsIdlingResource)
 
         // replaceText is needed here to go around autocorrect...
         onView(withId(R.id.session_name_input)).perform(replaceText("Ania's mobile bluetooth session"))
@@ -131,7 +124,7 @@ class MobileSessionTest {
         measurementValuesRow.check(matches(hasMinimumChildCount(1)))
 
         clickActionsButton()
-        Thread.sleep(1000)
+        Thread.sleep(2000)
         stopSession()
 
         Thread.sleep(4000)
@@ -172,7 +165,7 @@ class MobileSessionTest {
         onView(withId(R.id.session_actions_button)).perform(click())
 
         clickActionsButton()
-        Thread.sleep(1000)
+        Thread.sleep(2000)
         stopSession()
 
         Thread.sleep(4000)

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/TestAppComponent.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/TestAppComponent.kt
@@ -11,7 +11,8 @@ import javax.inject.Singleton
         SettingsModule::class,
         PermissionsModule::class,
         SensorsModule::class,
-        MockWebServerModule::class
+        MockWebServerModule::class,
+        NewSessionWizardModule::class
     ]
 )
 interface TestAppComponent: AppComponent {

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/di/FakeAirBeam2Connector.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/di/FakeAirBeam2Connector.kt
@@ -37,7 +37,7 @@ class FakeAirBeam2Connector(
             while (true) {
                 val inputStream = app.resources.openRawResource(R.raw.airbeam2_stream)
                 mAirBeam2Reader.run(inputStream)
-                sleep(3000)
+                sleep(1000)
                 inputStream.close()
             }
         }

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/di/FakeAirBeam2Connector.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/di/FakeAirBeam2Connector.kt
@@ -1,5 +1,6 @@
 package io.lunarlogic.aircasting.di
 
+import androidx.test.espresso.idling.CountingIdlingResource
 import io.lunarlogic.aircasting.AircastingApplication
 import io.lunarlogic.aircasting.R
 import io.lunarlogic.aircasting.exceptions.ErrorHandler
@@ -13,7 +14,8 @@ class FakeAirBeam2Connector(
     private val app: AircastingApplication,
     errorHandler: ErrorHandler,
     private val mAirBeamConfigurator: AirBeam2Configurator,
-    private val mAirBeam2Reader: AirBeam2Reader
+    private val mAirBeam2Reader: AirBeam2Reader,
+    private val mIdlingResource: CountingIdlingResource
 ): AirBeam2Connector(errorHandler, mAirBeamConfigurator, mAirBeam2Reader) {
     private val connectionStarted = AtomicBoolean(false)
     private var mThread: ConnectThread? = null
@@ -28,13 +30,14 @@ class FakeAirBeam2Connector(
 
     private inner class ConnectThread(private val deviceItem: DeviceItem) : Thread() {
         override fun run() {
-            sleep(3000) // we need to wait a bit, to test connecting screen properly
+            sleep(2000) // imitate connection time
             listener.onConnectionSuccessful(deviceItem.id)
+            mIdlingResource.decrement()
 
             while (true) {
                 val inputStream = app.resources.openRawResource(R.raw.airbeam2_stream)
                 mAirBeam2Reader.run(inputStream)
-                sleep(1000)
+                sleep(3000)
                 inputStream.close()
             }
         }

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/di/FakeAirBeam2Connector.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/di/FakeAirBeam2Connector.kt
@@ -14,8 +14,7 @@ class FakeAirBeam2Connector(
     private val app: AircastingApplication,
     errorHandler: ErrorHandler,
     private val mAirBeamConfigurator: AirBeam2Configurator,
-    private val mAirBeam2Reader: AirBeam2Reader,
-    private val mIdlingResource: CountingIdlingResource
+    private val mAirBeam2Reader: AirBeam2Reader
 ): AirBeam2Connector(errorHandler, mAirBeamConfigurator, mAirBeam2Reader) {
     private val connectionStarted = AtomicBoolean(false)
     private var mThread: ConnectThread? = null
@@ -30,11 +29,9 @@ class FakeAirBeam2Connector(
 
     private inner class ConnectThread(private val deviceItem: DeviceItem) : Thread() {
         override fun run() {
-            mIdlingResource.increment()
             sleep(2000) // imitate connection time
 
             listener.onConnectionSuccessful(deviceItem.id)
-            mIdlingResource.decrement()
 
             while (true) {
                 val inputStream = app.resources.openRawResource(R.raw.airbeam2_stream)

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/di/FakeAirBeam2Connector.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/di/FakeAirBeam2Connector.kt
@@ -30,7 +30,9 @@ class FakeAirBeam2Connector(
 
     private inner class ConnectThread(private val deviceItem: DeviceItem) : Thread() {
         override fun run() {
+            mIdlingResource.increment()
             sleep(2000) // imitate connection time
+
             listener.onConnectionSuccessful(deviceItem.id)
             mIdlingResource.decrement()
 

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/di/TestNewSessionWizardModule.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/di/TestNewSessionWizardModule.kt
@@ -1,0 +1,36 @@
+package io.lunarlogic.aircasting.di
+
+import android.content.Context
+import io.lunarlogic.aircasting.screens.new_session.session_details.*
+import io.lunarlogic.aircasting.sensor.Session
+
+class FakeFixedSessionDetailsController(
+    private val mContext: Context?,
+    private val mViewMvc: FixedSessionDetailsViewMvc
+): SessionDetailsController(mContext, mViewMvc) {
+    companion object {
+        val TEST_WIFI_SSID = "fake-wifi"
+    }
+    init {
+        mViewMvc.bindNetworks(listOf(Network(TEST_WIFI_SSID, 777)))
+    }
+}
+
+class FakeSessionDetailsControllerFactory: SessionDetailsControllerFactory() {
+    override fun get(context: Context?,
+                     view: SessionDetailsViewMvc,
+                     sessionType: Session.Type
+    ): SessionDetailsController {
+        if (sessionType == Session.Type.FIXED) {
+            return FakeFixedSessionDetailsController(context, view as FixedSessionDetailsViewMvcImpl)
+        }
+
+        return super.get(context, view, sessionType)
+    }
+}
+
+
+class TestNewSessionWizardModule: NewSessionWizardModule() {
+    override fun providesSessionDetailsControllerFactory(): SessionDetailsControllerFactory
+            = FakeSessionDetailsControllerFactory()
+}

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/di/TestSensorsModule.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/di/TestSensorsModule.kt
@@ -9,8 +9,7 @@ import io.lunarlogic.aircasting.sensor.airbeam2.AirBeam2Reader
 import io.lunarlogic.aircasting.sensor.microphone.AudioReader
 
 class TestSensorsModule(
-    private val app: AircastingApplication,
-    private val idlingResource: CountingIdlingResource
+    private val app: AircastingApplication
 ): SensorsModule() {
 
     override fun providesAirbeam2Connector(
@@ -18,7 +17,7 @@ class TestSensorsModule(
         airBeamConfigurator: AirBeam2Configurator,
         airBeam2Reader: AirBeam2Reader
     ): AirBeam2Connector {
-        return FakeAirBeam2Connector(app, errorHandler, airBeamConfigurator, airBeam2Reader, idlingResource)
+        return FakeAirBeam2Connector(app, errorHandler, airBeamConfigurator, airBeam2Reader)
     }
 
     override fun providesAudioReader(): AudioReader = FakeAudioReader(app)

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/di/TestSensorsModule.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/di/TestSensorsModule.kt
@@ -1,5 +1,6 @@
 package io.lunarlogic.aircasting.di
 
+import androidx.test.espresso.idling.CountingIdlingResource
 import io.lunarlogic.aircasting.AircastingApplication
 import io.lunarlogic.aircasting.exceptions.ErrorHandler
 import io.lunarlogic.aircasting.sensor.airbeam2.AirBeam2Configurator
@@ -7,13 +8,17 @@ import io.lunarlogic.aircasting.sensor.airbeam2.AirBeam2Connector
 import io.lunarlogic.aircasting.sensor.airbeam2.AirBeam2Reader
 import io.lunarlogic.aircasting.sensor.microphone.AudioReader
 
-class TestSensorsModule(private val app: AircastingApplication): SensorsModule() {
+class TestSensorsModule(
+    private val app: AircastingApplication,
+    private val idlingResource: CountingIdlingResource
+): SensorsModule() {
+
     override fun providesAirbeam2Connector(
         errorHandler: ErrorHandler,
         airBeamConfigurator: AirBeam2Configurator,
         airBeam2Reader: AirBeam2Reader
     ): AirBeam2Connector {
-        return FakeAirBeam2Connector(app, errorHandler, airBeamConfigurator, airBeam2Reader)
+        return FakeAirBeam2Connector(app, errorHandler, airBeamConfigurator, airBeam2Reader, idlingResource)
     }
 
     override fun providesAudioReader(): AudioReader = FakeAudioReader(app)

--- a/app/src/main/java/io/lunarlogic/aircasting/AppComponent.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/AppComponent.kt
@@ -1,10 +1,7 @@
 package io.lunarlogic.aircasting
 
 import dagger.Component
-import io.lunarlogic.aircasting.di.AppModule
-import io.lunarlogic.aircasting.di.PermissionsModule
-import io.lunarlogic.aircasting.di.SensorsModule
-import io.lunarlogic.aircasting.di.SettingsModule
+import io.lunarlogic.aircasting.di.*
 import io.lunarlogic.aircasting.screens.dashboard.fixed.FixedFragment
 import io.lunarlogic.aircasting.screens.dashboard.following.FollowingFragment
 import io.lunarlogic.aircasting.screens.dashboard.mobile.MobileActiveFragment
@@ -12,6 +9,7 @@ import io.lunarlogic.aircasting.screens.dashboard.mobile.MobileDormantFragment
 import io.lunarlogic.aircasting.screens.main.MainActivity
 import io.lunarlogic.aircasting.screens.new_session.LoginActivity
 import io.lunarlogic.aircasting.screens.new_session.NewSessionActivity
+import io.lunarlogic.aircasting.screens.new_session.session_details.SessionDetailsFragment
 import javax.inject.Singleton
 
 @Singleton
@@ -20,7 +18,8 @@ import javax.inject.Singleton
         AppModule::class,
         SettingsModule::class,
         PermissionsModule::class,
-        SensorsModule::class
+        SensorsModule::class,
+        NewSessionWizardModule::class
     ]
 )
 interface AppComponent {
@@ -32,4 +31,5 @@ interface AppComponent {
     fun inject(fragment: MobileDormantFragment)
     fun inject(fragment: FixedFragment)
     fun inject(activity: NewSessionActivity)
+    fun inject(fragment: SessionDetailsFragment)
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/di/NewSessionWizardModule.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/di/NewSessionWizardModule.kt
@@ -1,0 +1,14 @@
+package io.lunarlogic.aircasting.di
+
+import dagger.Module
+import dagger.Provides
+import io.lunarlogic.aircasting.screens.new_session.session_details.SessionDetailsControllerFactory
+import javax.inject.Singleton
+
+@Module
+open class NewSessionWizardModule {
+    @Provides
+    @Singleton
+    open fun providesSessionDetailsControllerFactory(): SessionDetailsControllerFactory
+            = SessionDetailsControllerFactory()
+}

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/session_details/SessionDetailsControllerFactory.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/session_details/SessionDetailsControllerFactory.kt
@@ -3,17 +3,15 @@ package io.lunarlogic.aircasting.screens.new_session.session_details
 import android.content.Context
 import io.lunarlogic.aircasting.sensor.Session
 
-class SessionDetailsControllerFactory {
-    companion object {
-        fun get(
-            context: Context?,
-            view: SessionDetailsViewMvc,
-            sessionType: Session.Type
-        ): SessionDetailsController {
-            return when(sessionType) {
-                Session.Type.MOBILE -> SessionDetailsController(context, view)
-                Session.Type.FIXED -> FixedSessionDetailsController(context, view as FixedSessionDetailsViewMvcImpl)
-            }
+open class SessionDetailsControllerFactory {
+    open fun get(
+        context: Context?,
+        view: SessionDetailsViewMvc,
+        sessionType: Session.Type
+    ): SessionDetailsController {
+        return when(sessionType) {
+            Session.Type.MOBILE -> SessionDetailsController(context, view)
+            Session.Type.FIXED -> FixedSessionDetailsController(context, view as FixedSessionDetailsViewMvcImpl)
         }
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/session_details/SessionDetailsFragment.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/session_details/SessionDetailsFragment.kt
@@ -5,7 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import io.lunarlogic.aircasting.AircastingApplication
 import io.lunarlogic.aircasting.sensor.Session
+import io.lunarlogic.aircasting.sensor.SessionBuilder
+import javax.inject.Inject
 
 class SessionDetailsFragment() : Fragment() {
     private lateinit var controller: SessionDetailsController
@@ -13,13 +16,19 @@ class SessionDetailsFragment() : Fragment() {
     lateinit var deviceId: String
     lateinit var sessionType: Session.Type
 
+    @Inject
+    lateinit var sessionDetailsControllerFactory: SessionDetailsControllerFactory
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        (activity?.application as AircastingApplication)
+            .appComponent.inject(this)
+
         val view = SessionDetailsViewFactory.get(inflater, container, childFragmentManager, deviceId, sessionType)
-        controller = SessionDetailsControllerFactory.get(context, view, sessionType)
+        controller = sessionDetailsControllerFactory.get(context, view, sessionType)
         controller.onCreate()
 
         return view.rootView


### PR DESCRIPTION
I was playing with the [idling resource](https://developer.android.com/training/testing/espresso/idling-resource), but it turned out it's much less reliable than just sleeps in the code... Maybe it's because the Firebase Test Lab nature, maybe because of the specific use cases in our app, but I had too often `java.lang.IllegalStateException: Counter has been corrupted! counterVal=-1` errors and I decided just to stick with sleeps.