### PR TITLE
Fixed syncing sessions and downloading measurements

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
@@ -39,7 +39,7 @@ interface MeasurementDao {
     fun insert(measurement: MeasurementDBObject): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertAll(measurements: List<MeasurementDBObject>)
+    fun insertAll(measurements: List<MeasurementDBObject>): List<Long>
 
     @Query("SELECT * FROM measurements WHERE session_id=:sessionId ORDER BY time DESC LIMIT 1")
     fun lastForSession(sessionId: Long): MeasurementDBObject

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/ConnectivityManager.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/ConnectivityManager.kt
@@ -11,7 +11,7 @@ import android.net.NetworkInfo
 import io.lunarlogic.aircasting.exceptions.ErrorHandler
 
 class ConnectivityManager(apiService: ApiService, context: Context): BroadcastReceiver() {
-    val sessionSyncService = SessionsSyncService(apiService, ErrorHandler(context))
+    val sessionSyncService = SessionsSyncService.get(apiService, ErrorHandler(context))
 
     companion object {
         val ACTION = ConnectivityManager.CONNECTIVITY_ACTION

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
@@ -27,7 +27,7 @@ abstract class SessionsController(
 ) : SessionsViewMvc.Listener {
     private val mErrorHandler = ErrorHandler(mRootActivity!!)
     private val mApiService =  ApiServiceFactory.get(mSettings.getAuthToken()!!)
-    private val mMobileSessionsSyncService = SessionsSyncService(mApiService, mErrorHandler)
+    protected val mMobileSessionsSyncService = SessionsSyncService.get(mApiService, mErrorHandler)
     private val mDownloadMeasurementsService = DownloadMeasurementsService(mApiService, mErrorHandler)
 
     protected lateinit var mSessionsLiveData: LiveData<List<SessionWithStreamsDBObject>>

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/SessionManager.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/SessionManager.kt
@@ -14,7 +14,7 @@ import org.greenrobot.eventbus.Subscribe
 
 class SessionManager(private val mContext: Context, private val apiService: ApiService) {
     private val errorHandler = ErrorHandler(mContext)
-    private val sessionsSyncService = SessionsSyncService(apiService, errorHandler)
+    private val sessionsSyncService = SessionsSyncService.get(apiService, errorHandler)
     private val fixedSessionUploadService = FixedSessionUploadService(apiService, errorHandler)
     private val fixedSessionDownloadMeasurementsService = FixedSessionDownloadMeasurementsService(apiService, errorHandler)
     private val sessionsRespository = SessionsRepository()


### PR DESCRIPTION
Only one sync can be triggered at once, otherwise concurrent requests can save dupplicates into db.
Additionally, measurements were saved in a loop instead in one query and it caused big delays and unstable behavior for longer sessions.