### PR TITLE
Fix now measurements - V1

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/events/NewFixedMeasurementsEvent.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/events/NewFixedMeasurementsEvent.kt
@@ -1,0 +1,5 @@
+package io.lunarlogic.aircasting.events
+
+import io.lunarlogic.aircasting.models.Session
+
+class NewFixedMeasurementsEvent(val session: Session)

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/DownloadMeasurementsCallback.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/DownloadMeasurementsCallback.kt
@@ -4,6 +4,7 @@ import io.lunarlogic.aircasting.database.DatabaseProvider
 import io.lunarlogic.aircasting.database.repositories.MeasurementStreamsRepository
 import io.lunarlogic.aircasting.database.repositories.MeasurementsRepository
 import io.lunarlogic.aircasting.database.repositories.SessionsRepository
+import io.lunarlogic.aircasting.events.NewFixedMeasurementsEvent
 import io.lunarlogic.aircasting.exceptions.DownloadMeasurementsError
 import io.lunarlogic.aircasting.exceptions.ErrorHandler
 import io.lunarlogic.aircasting.lib.DateConverter
@@ -12,6 +13,7 @@ import io.lunarlogic.aircasting.networking.responses.SessionWithMeasurementsResp
 import io.lunarlogic.aircasting.models.Measurement
 import io.lunarlogic.aircasting.models.MeasurementStream
 import io.lunarlogic.aircasting.models.Session
+import org.greenrobot.eventbus.EventBus
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -40,6 +42,7 @@ class DownloadMeasurementsCallback(
                         saveStreamData(streamResponse)
                     }
                     updateSessionEndTime(body?.end_time)
+                    EventBus.getDefault().post(NewFixedMeasurementsEvent(session))
                 }
             }
         } else {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -191,7 +191,6 @@ class MeasurementsTableContainer {
         } else {
             stream.measurements.lastOrNull()?.value
         }
-
         measurementValue ?: return
 
         val valueView = mLayoutInflater.inflate(R.layout.measurement_value, null, false)

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewController.kt
@@ -2,6 +2,7 @@ package io.lunarlogic.aircasting.screens.session_view
 
 import androidx.appcompat.app.AppCompatActivity
 import io.lunarlogic.aircasting.database.DatabaseProvider
+import io.lunarlogic.aircasting.events.NewFixedMeasurementsEvent
 import io.lunarlogic.aircasting.events.NewMeasurementEvent
 import io.lunarlogic.aircasting.location.LocationHelper
 import io.lunarlogic.aircasting.models.*
@@ -43,6 +44,13 @@ abstract class SessionDetailsViewController(
             val measurement = Measurement(event, location?.latitude , location?.longitude)
 
             mViewMvc.addMeasurement(measurement)
+        }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onMessageEvent(event: NewFixedMeasurementsEvent) {
+        if (event.session.uuid == mSessionPresenter.sessionUUID) {
+            mViewMvc.addFixedMeasurements()
         }
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvc.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvc.kt
@@ -2,6 +2,7 @@ package io.lunarlogic.aircasting.screens.session_view
 
 import android.location.Location
 import io.lunarlogic.aircasting.models.Measurement
+import io.lunarlogic.aircasting.models.Session
 import io.lunarlogic.aircasting.screens.common.ObservableViewMvc
 import io.lunarlogic.aircasting.screens.dashboard.SessionPresenter
 import io.lunarlogic.aircasting.screens.session_view.hlu.HLUListener
@@ -10,6 +11,7 @@ interface SessionDetailsViewMvc: ObservableViewMvc<SessionDetailsViewMvc.Listene
     fun bindSession(sessionPresenter: SessionPresenter?)
 
     fun addMeasurement(measurement: Measurement)
+    fun addFixedMeasurements()
     fun centerMap(location: Location)
 
     interface Listener: HLUListener {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -83,6 +83,10 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
         mStatisticsContainer?.addMeasurement(measurement)
     }
 
+    override fun addFixedMeasurements() {
+        mStatisticsContainer?.addFixedMeasurement(mSessionPresenter)
+    }
+
     override fun bindSession(sessionPresenter: SessionPresenter?) {
         mSessionPresenter = sessionPresenter
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
@@ -66,6 +66,15 @@ class StatisticsContainer {
         }
     }
 
+    fun addFixedMeasurement(sessionPresenter: SessionPresenter?) {
+        val stream = sessionPresenter?.selectedStream
+        mSum = stream?.calculateSum()
+        mNow = getNowValue(stream)
+        if (mPeak != null && mNow != null && mNow!! > mPeak!!) {
+            mPeak = mNow
+        }
+    }
+
     fun refresh(sessionPresenter: SessionPresenter?) {
         mSum = null
         mPeak = null
@@ -115,7 +124,7 @@ class StatisticsContainer {
         return stream.measurements.maxBy { it.value }?.value ?: 0.0
     }
 
-    private fun getNowValue(stream: MeasurementStream): Double? {
-        return stream.measurements.lastOrNull()?.value
+    private fun getNowValue(stream: MeasurementStream?): Double? {
+        return stream?.measurements?.lastOrNull()?.value
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
@@ -88,6 +88,10 @@ class StatisticsContainer {
     }
 
     private fun bindNowStatistics(stream: MeasurementStream?) {
+        if (mNow == null && stream != null) {
+            mNow = getNowValue(stream)
+        }
+
         bindStatisticValues(stream, mNow, mNowValue, mNowCircleIndicator)
     }
 
@@ -109,5 +113,9 @@ class StatisticsContainer {
 
     private fun calculatePeak(stream: MeasurementStream): Double {
         return stream.measurements.maxBy { it.value }?.value ?: 0.0
+    }
+
+    private fun getNowValue(stream: MeasurementStream): Double? {
+        return stream.measurements.lastOrNull()?.value
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam2/AirBeam2Reader.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam2/AirBeam2Reader.kt
@@ -25,7 +25,9 @@ class AirBeam2Reader(private val mErrorHandler: ErrorHandler) {
             override fun processLine(line: String): Boolean {
 
                 val newMeasurementEvent = responseParser.parse(line)
-                newMeasurementEvent?.let { EventBus.getDefault().post(newMeasurementEvent) }
+                newMeasurementEvent?.let {
+                    EventBus.getDefault().post(newMeasurementEvent)
+                }
 
                 return true
             }

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam3/AirBeam3Reader.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam3/AirBeam3Reader.kt
@@ -17,7 +17,9 @@ class AirBeam3Reader(
 
         if (!dataString.isEmpty()) {
             val newMeasurementEvent = responseParser.parse(dataString)
-            newMeasurementEvent?.let { EventBus.getDefault().post(newMeasurementEvent) }
+            newMeasurementEvent?.let {
+                EventBus.getDefault().post(newMeasurementEvent)
+            }
         }
     }
 }


### PR DESCRIPTION
This is a first version of fixing "Now" measurements in statistics container. This one is using an event on database update. it is not ideal because DB update != sessionPresenter update, so we have difference between measurements table and statistics table sometimes.