### PR TITLE
Fix now measurements - V2

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -79,9 +79,7 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
         mListener = null
     }
 
-    override fun addMeasurement(measurement: Measurement) {
-        mStatisticsContainer?.addMeasurement(measurement)
-    }
+    override fun addMeasurement(measurement: Measurement) {}
 
     override fun bindSession(sessionPresenter: SessionPresenter?) {
         mSessionPresenter = sessionPresenter

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -92,7 +92,7 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
         mHLUSlider.bindSensorThreshold(sessionPresenter?.selectedSensorThreshold())
     }
 
-    fun showSlider() {
+    private fun showSlider() {
         mMoreButton?.visibility = View.VISIBLE
         mHLUSlider.show()
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
@@ -51,23 +51,10 @@ class StatisticsContainer {
 
         mStatisticsView?.visibility = View.VISIBLE
 
-        if(sessionPresenter != null && sessionPresenter?.isFixed()) {
-            bindLastMeasurement(sessionPresenter)
-        }
-
+        bindLastMeasurement(sessionPresenter)
         bindAvgStatistics(stream)
         bindNowStatistics(stream)
         bindPeakStatistics(stream)
-    }
-
-    fun addMeasurement(measurement: Measurement) {
-        mSum?.let { mSum = it + measurement.value }
-
-        mNow = measurement.value
-
-        if (mPeak != null && measurement.value > mPeak!!) {
-            mPeak = measurement.value
-        }
     }
 
     private fun bindLastMeasurement(sessionPresenter: SessionPresenter?) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
@@ -72,8 +72,9 @@ class StatisticsContainer {
 
     private fun bindLastMeasurement(sessionPresenter: SessionPresenter?) {
         val stream = sessionPresenter?.selectedStream
-        mSum = stream?.calculateSum()
+
         mNow = getNowValue(stream)
+        mSum?.let { mSum = it + (mNow ?: 0.0) }
         if (mPeak != null && mNow != null && mNow!! > mPeak!!) {
             mPeak = mNow
         }
@@ -93,7 +94,6 @@ class StatisticsContainer {
             if (mSum == null) {
                 mSum = stream.calculateSum()
             }
-
             avg = mSum!! / stream.measurements.size
         }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
@@ -51,6 +51,10 @@ class StatisticsContainer {
 
         mStatisticsView?.visibility = View.VISIBLE
 
+        if(sessionPresenter != null && sessionPresenter?.isFixed()) {
+            bindLastMeasurement(sessionPresenter)
+        }
+
         bindAvgStatistics(stream)
         bindNowStatistics(stream)
         bindPeakStatistics(stream)
@@ -63,6 +67,15 @@ class StatisticsContainer {
 
         if (mPeak != null && measurement.value > mPeak!!) {
             mPeak = measurement.value
+        }
+    }
+
+    private fun bindLastMeasurement(sessionPresenter: SessionPresenter?) {
+        val stream = sessionPresenter?.selectedStream
+        mSum = stream?.calculateSum()
+        mNow = getNowValue(stream)
+        if (mPeak != null && mNow != null && mNow!! > mPeak!!) {
+            mPeak = mNow
         }
     }
 
@@ -88,6 +101,9 @@ class StatisticsContainer {
     }
 
     private fun bindNowStatistics(stream: MeasurementStream?) {
+        if (mNow == null && stream != null) {
+            mNow = getNowValue(stream)
+        }
         bindStatisticValues(stream, mNow, mNowValue, mNowCircleIndicator)
     }
 
@@ -109,5 +125,9 @@ class StatisticsContainer {
 
     private fun calculatePeak(stream: MeasurementStream): Double {
         return stream.measurements.maxBy { it.value }?.value ?: 0.0
+    }
+
+    private fun getNowValue(stream: MeasurementStream?): Double? {
+        return stream?.measurements?.lastOrNull()?.value
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
@@ -64,10 +64,6 @@ class GraphContainer: OnChartGestureListener {
         drawSession()
     }
 
-    fun addMeasurement(measurement: Measurement) {
-        refresh(mSessionPresenter)
-    }
-
     fun refresh(sessionPresenter: SessionPresenter?) {
         bindSession(sessionPresenter)
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphViewMvcImpl.kt
@@ -39,11 +39,6 @@ abstract class GraphViewMvcImpl: SessionDetailsViewMvcImpl {
         graphContainer.unregisterListener()
     }
 
-    override fun addMeasurement(measurement: Measurement) {
-        super.addMeasurement(measurement)
-        graphContainer.addMeasurement(measurement)
-    }
-
     override fun bindSession(sessionPresenter: SessionPresenter?) {
         super.bindSession(sessionPresenter)
         graphContainer.bindSession(mSessionPresenter)

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
@@ -185,7 +185,7 @@ class MapContainer: OnMapReadyCallback {
         mMap?.moveCamera(CameraUpdateFactory.newLatLngZoom(position, DEFAULT_ZOOM))
     }
 
-    fun addMeasurement(measurement: Measurement) {
+    fun addMobileMeasurement(measurement: Measurement) {
         if (mSessionPresenter?.isRecording() == true) {
             drawMobileMeasurement(measurementColorPoint(measurement))
         }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
@@ -93,6 +93,9 @@ class MapContainer: OnMapReadyCallback {
         mSessionPresenter = sessionPresenter
         mMeasurements = measurementsWithLocations(mSessionPresenter?.selectedStream)
 
+        if (mSessionPresenter?.isFixed() == true) {
+            drawFixedMeasurement()
+        }
         // sometimes onMapReady is invoked earlier than bindStream
         if (status.get() == Status.MAP_LOADED.value) {
             setup()
@@ -131,7 +134,8 @@ class MapContainer: OnMapReadyCallback {
         }
     }
 
-    private fun drawLastMeasurementMarker(point: LatLng, color: Int) {
+    private fun drawLastMeasurementMarker(point: LatLng?, color: Int?) {
+        if (point == null || color == null) return
         if (mLastMeasurementMarker != null) mLastMeasurementMarker!!.remove()
 
         val icon = BitmapHelper.bitmapFromVector(mContext, R.drawable.ic_dot_20, color)
@@ -182,25 +186,21 @@ class MapContainer: OnMapReadyCallback {
     }
 
     fun addMeasurement(measurement: Measurement) {
-        if (measurement.latitude == null || measurement.longitude == null) return
-
-        val point = LatLng(measurement.latitude, measurement.longitude)
-        val color = MeasurementColor.forMap(mContext, measurement, mSessionPresenter?.selectedSensorThreshold())
-
-        if (mSessionPresenter?.isFixed() == true) {
-            drawFixedMeasurement(point, color)
-        } else if (mSessionPresenter?.isRecording() == true) {
-            drawMobileMeasurement(point, color)
+        if (mSessionPresenter?.isRecording() == true) {
+            drawMobileMeasurement(measurementColorPoint(measurement))
         }
     }
 
-    private fun drawFixedMeasurement(point: LatLng, color: Int) {
-        drawLastMeasurementMarker(point, color)
+    private fun drawFixedMeasurement() {
+        val colorPoint = measurementColorPoint(mMeasurements.last())
+        drawLastMeasurementMarker(colorPoint?.point, colorPoint?.color)
     }
 
-    private fun drawMobileMeasurement(point: LatLng, color: Int) {
-        mMeasurementPoints.add(point)
-        mMeasurementSpans.add(StyleSpan(color))
+    private fun drawMobileMeasurement(colorPoint: ColorPoint?) {
+        if (colorPoint == null) return
+
+        mMeasurementPoints.add(colorPoint.point)
+        mMeasurementSpans.add(StyleSpan(colorPoint.color))
 
         if (mMeasurementsLine == null) {
             mMeasurementsLine = mMap?.addPolyline(mMeasurementsLineOptions)
@@ -209,7 +209,16 @@ class MapContainer: OnMapReadyCallback {
         mMeasurementsLine?.setPoints(mMeasurementPoints)
         mMeasurementsLine?.setSpans(mMeasurementSpans)
 
-        drawLastMeasurementMarker(point, color)
+        drawLastMeasurementMarker(colorPoint.point, colorPoint.color)
+    }
+
+    private fun measurementColorPoint(measurement: Measurement) : ColorPoint? {
+        if (measurement.latitude == null || measurement.longitude == null) return null
+
+        val point = LatLng(measurement.latitude, measurement.longitude)
+        val color = MeasurementColor.forMap(mContext, measurement, mSessionPresenter?.selectedSensorThreshold())
+
+        return ColorPoint(point, color)
     }
 
     fun refresh(sessionPresenter: SessionPresenter?) {
@@ -238,3 +247,5 @@ class MapContainer: OnMapReadyCallback {
             .startCap(RoundCap())
     }
 }
+
+data class ColorPoint(val point: LatLng, val color: Int)

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapViewMvcImpl.kt
@@ -40,7 +40,7 @@ abstract class MapViewMvcImpl: SessionDetailsViewMvcImpl {
 
     override fun addMeasurement(measurement: Measurement) {
         super.addMeasurement(measurement)
-        mMapContainer.addMeasurement(measurement)
+        mMapContainer.addMobileMeasurement(measurement)
     }
 
     override fun bindSession(sessionPresenter: SessionPresenter?) {

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam2/AirBeam2Reader.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam2/AirBeam2Reader.kt
@@ -8,6 +8,12 @@ import org.greenrobot.eventbus.EventBus
 import java.io.InputStream
 import java.io.InputStreamReader
 
+/**
+ * This reader will be effectively use only in MOBILE sessions
+ * Only when AirBeam is in the MOBILE mode the data is sent to the Android device
+ * No NewMeasurementEvent will be posted for FIXED sessions
+ */
+
 class AirBeam2Reader(private val mErrorHandler: ErrorHandler) {
     fun run(inputStream: InputStream) {
         val inputStreamReader = InputStreamReader(inputStream)

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam3/AirBeam3Reader.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam3/AirBeam3Reader.kt
@@ -5,6 +5,12 @@ import io.lunarlogic.aircasting.sensor.ResponseParser
 import no.nordicsemi.android.ble.data.Data
 import org.greenrobot.eventbus.EventBus
 
+/**
+ * This reader will be effectively use only in MOBILE sessions
+ * Only when AirBeam is in the MOBILE mode the data is sent to the Android device
+ * No NewMeasurementEvent will be posted for FIXED sessions
+ */
+
 class AirBeam3Reader(
     errorHandler: ErrorHandler
 ) {


### PR DESCRIPTION
Version 2 of fixing statistics container update for fixed sessions. This one is not using events, just updating the statistics according to the last measurements when we do bindSession (same way as measurements table).

I changed the way:
-  StatisticsContainer measurements are updated (both Graph and Map) -> now we don't rely on NewMeasurementEvent on neither fixed nor mobile sessions
- Graph is updated -> now we don't rely on NewMeasurementEvent on neither fixed nor mobile sessions AND the graph is redrawn only once on bindSession (it used to be drawn twice on mobile sessions)
- Map is updated -> actually previously the point was not redrawn ever for fixed session (only on stream changed we redraw map) so I fixed it