### PR TITLE
Graph - user should not need to scroll to see last measurements.

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
@@ -80,7 +80,6 @@ class GraphContainer: OnChartGestureListener {
 
         mGraph?.invalidate()
         mGraph?.calculateOffsets()
-        mGraph?.setViewPortOffsets(0f, 0f, 0f, 0f)
     }
 
     private fun generateData(): GraphDataGenerator.Result {
@@ -103,26 +102,13 @@ class GraphContainer: OnChartGestureListener {
         val last = entries.lastOrNull() ?: return
 
         val span = last.x - first.x
-        println("MARYSIA: graph FROM  Math.max(last.x - mDefaultZoomSpan, first.x): "+mGraphDataGenerator.dateFromFloat(Math.max(last.x - mDefaultZoomSpan, first.x)))
-        println("MARYSIA: graph TO last.x: "+mGraphDataGenerator.dateFromFloat(last.x))
         val zoom = span / mDefaultZoomSpan
-//        val zoom = mDefaultZoomSpan.toFloat()
-        println("MARYSIA: span: "+span)
-        println("MARYSIA: zoom: "+zoom)
-//        val centerX = span / 2
-        val centerX = last.x - mDefaultZoomSpan/2
-
-        println("MARYSIA: centerX: "+centerX)
+        val centerX = last.x - Math.min(mDefaultZoomSpan.toFloat(), span)/2
         val centerY = (last.y - first.y) / 2
 
         mGraph.zoom(zoom, 1f, centerX, centerY)
 
-//        val from = first.x
         val from = Math.max(last.x - mDefaultZoomSpan, first.x)
-        println("MARYSIA: Math.max(last.x - mDefaultZoomSpan, first.x): "+Math.max(last.x - mDefaultZoomSpan, first.x))
-        println("MARYSIA:last.x - mDefaultZoomSpan: "+(last.x - mDefaultZoomSpan))
-        println("MARYSIA:first.x: "+first.x)
-//        mGraph.moveViewToX(last.x)
         val to = last.x
         drawLabels(from, to)
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
@@ -103,15 +103,27 @@ class GraphContainer: OnChartGestureListener {
         val last = entries.lastOrNull() ?: return
 
         val span = last.x - first.x
+        println("MARYSIA: graph FROM  Math.max(last.x - mDefaultZoomSpan, first.x): "+mGraphDataGenerator.dateFromFloat(Math.max(last.x - mDefaultZoomSpan, first.x)))
+        println("MARYSIA: graph TO last.x: "+mGraphDataGenerator.dateFromFloat(last.x))
         val zoom = span / mDefaultZoomSpan
-        val centerX = span / 2
+//        val zoom = mDefaultZoomSpan.toFloat()
+        println("MARYSIA: span: "+span)
+        println("MARYSIA: zoom: "+zoom)
+//        val centerX = span / 2
+        val centerX = last.x - mDefaultZoomSpan/2
+
+        println("MARYSIA: centerX: "+centerX)
         val centerY = (last.y - first.y) / 2
 
         mGraph.zoom(zoom, 1f, centerX, centerY)
-        mGraph.moveViewToX(first.x)
 
-        val from = first.x
-        val to = Math.min(from + mDefaultZoomSpan, last.x)
+//        val from = first.x
+        val from = Math.max(last.x - mDefaultZoomSpan, first.x)
+        println("MARYSIA: Math.max(last.x - mDefaultZoomSpan, first.x): "+Math.max(last.x - mDefaultZoomSpan, first.x))
+        println("MARYSIA:last.x - mDefaultZoomSpan: "+(last.x - mDefaultZoomSpan))
+        println("MARYSIA:first.x: "+first.x)
+//        mGraph.moveViewToX(last.x)
+        val to = last.x
         drawLabels(from, to)
 
         shouldZoomToDefault = false

--- a/app/src/main/res/layout/graph.xml
+++ b/app/src/main/res/layout/graph.xml
@@ -5,7 +5,9 @@
         android:id="@+id/graph"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginTop="@dimen/keyline_4"
+        android:layout_marginTop="-15dp"
+        android:layout_marginStart="-15.5dp"
+        android:layout_marginEnd="-15dp"
         app:layout_constraintTop_toBottomOf="@id/measurements_table"
         app:layout_constraintBottom_toTopOf="@id/from_label"/>
 
@@ -14,7 +16,7 @@
         android:text="from"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_2"
+        android:layout_marginTop="0dp"
         android:layout_marginStart="@dimen/keyline_4"
         android:layout_marginBottom="@dimen/keyline_3"
         android:textSize="@dimen/text_size_xxs"
@@ -27,7 +29,7 @@
         android:text="to"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_2"
+        android:layout_marginTop="0dp"
         android:layout_marginEnd="@dimen/keyline_4"
         android:layout_marginBottom="@dimen/keyline_3"
         android:textSize="@dimen/text_size_xxs"


### PR DESCRIPTION
From the graph library documentation of setViewPortOffsets() method: "ONLY USE THIS WHEN YOU KNOW WHAT YOU ARE DOING" - well, apparently, I didn't.

This is supposed to fix https://trello.com/c/aSeAVwgt/1034-following-fixed-graph-default-view-should-display-most-recent-measurement-ie-user-shouldnt-need-to-scroll-right-to-view-most-rec