### PR TITLE
Fixes for disconnect view

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionPresenter.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionPresenter.kt
@@ -63,6 +63,10 @@ class SessionPresenter() {
         return !isFixed() && !isRecording()
     }
 
+    fun isMobileActive(): Boolean {
+        return !isFixed() && isRecording()
+    }
+
     fun isRecording(): Boolean {
         return session?.isRecording() == true
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvc.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvc.kt
@@ -6,6 +6,4 @@ interface SessionViewMvc<ListenerType>: ObservableViewMvc<ListenerType> {
     fun bindSession(sessionPresenter: SessionPresenter)
     fun showLoader()
     fun hideLoader()
-    fun showReconnectingLoader()
-    fun hideReconnectingLoader()
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -22,21 +22,16 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
     protected val mLayoutInflater: LayoutInflater
     protected val mMeasurementsTableContainer: MeasurementsTableContainer
 
-    private val mSessionCardLayout: ViewGroup
-
-    private val mDisconnectedView: View
-    private val mReconnectButton: Button
-    private val mReconnectingLoader: ImageView
-    private val mFinishButton: Button
+    protected val mSessionCardLayout: ViewGroup
 
     private val mDateTextView: TextView
     private val mNameTextView: TextView
     private val mInfoTextView: TextView
-    private val mActionsButton: ImageView
+    protected val mActionsButton: ImageView
     private val mSupportFragmentManager: FragmentManager
     protected var mBottomSheet: BottomSheet? = null
 
-    private var mExpandedSessionView: View
+    protected var mExpandedSessionView: View
     protected var mExpandSessionButton: ImageView
     protected var mCollapseSessionButton: ImageView
     protected val mChart: Chart
@@ -67,13 +62,6 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         mNameTextView = findViewById(R.id.session_name)
         mInfoTextView = findViewById(R.id.session_info)
         mMeasurementsDescription = findViewById(R.id.session_measurements_description)
-
-        mDisconnectedView = findViewById(R.id.disconnected_view)
-        mReconnectButton = findViewById(R.id.disconnected_view_bluetooth_device_reconnect_button)
-        mReconnectButton.setOnClickListener { reconnectSessionPressed() }
-        mReconnectingLoader = findViewById(R.id.reconnecting_loader)
-        mFinishButton = findViewById(R.id.disconnected_view_bluetooth_device_finish_button)
-        mFinishButton.setOnClickListener { stopSessionPressed() }
 
         mMeasurementsTableContainer = MeasurementsTableContainer(
             context,
@@ -151,12 +139,10 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
 
     override fun bindSession(sessionPresenter: SessionPresenter) {
         bindLoader(sessionPresenter)
-        bindReconnectingLoader(sessionPresenter)
         bindExpanded(sessionPresenter)
         bindSelectedStream(sessionPresenter)
         bindSessionDetails()
         bindMeasurementsDescription(sessionPresenter)
-        bindDisconnectedInfo(sessionPresenter)
         bindMeasurementsTable()
         bindChartData()
         bindFollowButtons(sessionPresenter)
@@ -167,14 +153,6 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
             showLoader()
         } else {
             hideLoader()
-        }
-    }
-
-    private fun bindReconnectingLoader(sessionPresenter: SessionPresenter) {
-        if (sessionPresenter.reconnecting) {
-            showReconnectingLoader()
-        } else {
-            hideReconnectingLoader()
         }
     }
 
@@ -209,21 +187,7 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         }
     }
 
-    private fun bindDisconnectedInfo(sessionPresenter: SessionPresenter) {
-        if (sessionPresenter.isDisconnected()) {
-            mDisconnectedView.visibility = View.VISIBLE
-            mActionsButton.visibility = View.GONE
-            mExpandSessionButton.visibility = View.GONE
-            mSessionCardLayout.background = context.getDrawable(R.drawable.top_border)
 
-            mExpandedSessionView.visibility = View.GONE
-        } else {
-            mDisconnectedView.visibility = View.GONE
-            mActionsButton.visibility = View.VISIBLE
-            mExpandSessionButton.visibility = View.VISIBLE
-            mSessionCardLayout.background = null
-        }
-    }
 
     protected open fun bindMeasurementsTable() {
         mMeasurementsTableContainer.bindSession(mSessionPresenter, this::onMeasurementStreamChanged)
@@ -278,25 +242,6 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
 
     override fun hideLoader() {
         mLoader?.visibility = View.GONE
-    }
-
-    override fun showReconnectingLoader() {
-        AnimatedLoader(mReconnectingLoader).start()
-        mReconnectingLoader.visibility = View.VISIBLE
-        mReconnectButton.isEnabled = false
-
-        // we need to revert default translation set in
-        // Widget.Aircasting.Button for disabled button state
-        mReconnectButton.translationZ = -context.resources.getDimension(R.dimen.button_shadow_translation)
-    }
-
-    override fun hideReconnectingLoader() {
-        mReconnectingLoader.visibility = View.GONE
-        mReconnectButton.isEnabled = true
-
-        // we need to set default translation from Widget.Aircasting.Button
-        // back again after reverting in showReconnectingLoader()
-        mReconnectButton.translationZ = context.resources.getDimension(R.dimen.button_shadow_translation)
     }
 
     protected fun onMeasurementStreamChanged(measurementStream: MeasurementStream) {
@@ -361,7 +306,4 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
     private fun onCollapseSessionCardClicked() {
         mSessionPresenter?.expanded = false
     }
-
-    protected open fun reconnectSessionPressed() {}
-    protected open fun stopSessionPressed() {}
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/DisconnectedView.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/DisconnectedView.kt
@@ -1,0 +1,104 @@
+package io.lunarlogic.aircasting.screens.dashboard.active
+
+import android.content.Context
+import android.view.View
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import io.lunarlogic.aircasting.R
+import io.lunarlogic.aircasting.lib.AnimatedLoader
+import io.lunarlogic.aircasting.models.Session
+import io.lunarlogic.aircasting.screens.dashboard.SessionPresenter
+import kotlinx.android.synthetic.main.disconnected_view.view.*
+
+class DisconnectedView {
+    private val mContext: Context
+    private val mListener: MobileActiveSessionViewMvc.DisconnectedViewListener
+
+    private val mDisconnectedView: View?
+    private val mHeader: TextView?
+    private val mDescription: TextView?
+    private val mPrimaryButton: Button?
+    private val mSecondaryButton: Button?
+    private val mReconnectingLoader: ImageView?
+
+    constructor(context: Context, rootView: View?, listener: MobileActiveSessionViewMvc.DisconnectedViewListener) {
+        mContext = context
+        mListener = listener
+
+        mDisconnectedView = rootView?.disconnected_view
+        mHeader = rootView?.disconnected_view_bluetooth_device_header
+        mDescription = rootView?.disconnected_view_bluetooth_device_description
+        mPrimaryButton = rootView?.disconnected_view_bluetooth_device_reconnect_button
+        mSecondaryButton = rootView?.disconnected_view_bluetooth_device_finish_button
+        mReconnectingLoader = rootView?.reconnecting_loader
+    }
+
+    fun show(sessionPresenter: SessionPresenter) {
+        val session = sessionPresenter.session
+        session ?: return
+
+        if (session.isAirBeam3()) {
+            bindAirBeam3(session)
+        } else {
+            bindBluetoothDevice(session)
+        }
+
+        bindReconnectingLoader(sessionPresenter)
+
+        mDisconnectedView?.visibility = View.VISIBLE
+    }
+
+    fun hide() {
+        mDisconnectedView?.visibility = View.GONE
+    }
+
+    private fun bindReconnectingLoader(sessionPresenter: SessionPresenter) {
+        if (sessionPresenter.reconnecting) {
+            showReconnectingLoader()
+        } else {
+            hideReconnectingLoader()
+        }
+    }
+
+    private fun bindBluetoothDevice(session: Session) {
+        mHeader?.text = mContext.getString(R.string.disconnected_view_bluetooth_device_header)
+        mDescription?.text = mContext.getString(R.string.disconnected_view_bluetooth_device_description)
+        mPrimaryButton?.text = mContext.getString(R.string.disconnected_view_bluetooth_device_reconnect_button)
+        mSecondaryButton?.text = mContext.getString(R.string.disconnected_view_bluetooth_device_finish_button)
+
+        mPrimaryButton?.setOnClickListener { mListener.onSessionReconnectClicked(session) }
+        mSecondaryButton?.setOnClickListener { mListener.onSessionStopClicked(session) }
+    }
+
+    private fun bindAirBeam3(session: Session) {
+        mHeader?.text = mContext.getString(R.string.disconnected_view_airbeam3_header)
+        mDescription?.text = mContext.getString(R.string.disconnected_view_airbeam3_description)
+        mPrimaryButton?.text = mContext.getString(R.string.disconnected_view_airbeam3_sync_button)
+        mSecondaryButton?.text = mContext.getString(R.string.disconnected_view_airbeam3_finish_button)
+
+        mPrimaryButton?.setOnClickListener {
+            // TODO: add when sync will be implemented
+        }
+        mSecondaryButton?.setOnClickListener { mListener.onSessionStopClicked(session) }
+    }
+
+    private fun showReconnectingLoader() {
+        AnimatedLoader(mReconnectingLoader).start()
+        mReconnectingLoader?.visibility = View.VISIBLE
+        mPrimaryButton?.isEnabled = false
+
+        // we need to revert default translation set in
+        // Widget.Aircasting.Button for disabled button state
+        mPrimaryButton?.translationZ = -mContext.resources.getDimension(R.dimen.button_shadow_translation)
+    }
+
+    private fun hideReconnectingLoader() {
+        mReconnectingLoader?.visibility = View.GONE
+        mPrimaryButton?.isEnabled = true
+
+        // we need to set default translation from Widget.Aircasting.Button
+        // back again after reverting in showReconnectingLoader()
+        mPrimaryButton?.translationZ = mContext.resources.getDimension(R.dimen.button_shadow_translation)
+    }
+}

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveController.kt
@@ -2,10 +2,7 @@ package io.lunarlogic.aircasting.screens.dashboard.active
 
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.LifecycleOwner
-import io.lunarlogic.aircasting.bluetooth.BluetoothManager
-import io.lunarlogic.aircasting.events.DisconnectExternalSensorsEvent
 import io.lunarlogic.aircasting.events.StopRecordingEvent
-import io.lunarlogic.aircasting.exceptions.BLENotSupported
 import io.lunarlogic.aircasting.lib.NavigationController
 import io.lunarlogic.aircasting.lib.Settings
 import io.lunarlogic.aircasting.models.observers.ActiveSessionsObserver
@@ -15,9 +12,6 @@ import io.lunarlogic.aircasting.networking.services.ApiServiceFactory
 import io.lunarlogic.aircasting.screens.dashboard.DashboardPagerAdapter
 import io.lunarlogic.aircasting.screens.dashboard.SessionsController
 import io.lunarlogic.aircasting.screens.dashboard.SessionsViewMvc
-import io.lunarlogic.aircasting.screens.new_session.select_device.DeviceItem
-import io.lunarlogic.aircasting.sensor.AirBeamConnector
-import io.lunarlogic.aircasting.sensor.AirBeamConnectorFactory
 import io.lunarlogic.aircasting.sensor.AirBeamReconnector
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveSessionViewMvc.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveSessionViewMvc.kt
@@ -6,9 +6,13 @@ import io.lunarlogic.aircasting.screens.dashboard.SessionViewMvc
 
 interface MobileActiveSessionViewMvc:
     SessionViewMvc<MobileActiveSessionViewMvc.Listener> {
-    interface Listener: SessionCardListener {
-        fun onSessionDisconnectClicked(session: Session)
+
+    interface DisconnectedViewListener {
         fun onSessionReconnectClicked(session: Session)
         fun onSessionStopClicked(session: Session)
+    }
+
+    interface Listener: SessionCardListener, DisconnectedViewListener {
+        fun onSessionDisconnectClicked(session: Session)
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveSessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveSessionViewMvcImpl.kt
@@ -1,23 +1,32 @@
 package io.lunarlogic.aircasting.screens.dashboard.active
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.FragmentManager
 import io.lunarlogic.aircasting.R
+import io.lunarlogic.aircasting.models.Session
 import io.lunarlogic.aircasting.screens.common.BottomSheet
 import io.lunarlogic.aircasting.screens.dashboard.ActiveSessionActionsBottomSheet
 import io.lunarlogic.aircasting.screens.dashboard.SessionPresenter
 import io.lunarlogic.aircasting.screens.dashboard.SessionViewMvcImpl
 
-class MobileActiveSessionViewMvcImpl(
-    inflater: LayoutInflater,
-    parent: ViewGroup,
-    supportFragmentManager: FragmentManager
-):
-    SessionViewMvcImpl<MobileActiveSessionViewMvc.Listener>(inflater, parent, supportFragmentManager),
+class MobileActiveSessionViewMvcImpl: SessionViewMvcImpl<MobileActiveSessionViewMvc.Listener>,
     MobileActiveSessionViewMvc,
+    MobileActiveSessionViewMvc.DisconnectedViewListener,
     ActiveSessionActionsBottomSheet.Listener
 {
+
+    private val mDisconnectedView: DisconnectedView
+
+    constructor(
+        inflater: LayoutInflater,
+        parent: ViewGroup,
+        supportFragmentManager: FragmentManager
+    ): super(inflater, parent, supportFragmentManager) {
+        mDisconnectedView = DisconnectedView(context, this.rootView, this)
+    }
+
     override fun showMeasurementsTableValues(): Boolean {
         return true
     }
@@ -36,6 +45,29 @@ class MobileActiveSessionViewMvcImpl(
         return ActiveSessionActionsBottomSheet(this, sessionPresenter)
     }
 
+    override fun bindSession(sessionPresenter: SessionPresenter) {
+        super.bindSession(sessionPresenter)
+        bindDisconnectedInfo(sessionPresenter)
+    }
+
+    private fun bindDisconnectedInfo(sessionPresenter: SessionPresenter) {
+        if (sessionPresenter.isDisconnected()) {
+            mDisconnectedView.show(sessionPresenter)
+
+            mActionsButton.visibility = View.GONE
+            mExpandSessionButton.visibility = View.GONE
+            mSessionCardLayout.background = context.getDrawable(R.drawable.top_border)
+
+            mExpandedSessionView.visibility = View.GONE
+        } else {
+            mDisconnectedView.hide()
+
+            mActionsButton.visibility = View.VISIBLE
+            mExpandSessionButton.visibility = View.VISIBLE
+            mSessionCardLayout.background = null
+        }
+    }
+
     override fun disconnectSessionPressed() {
         for (listener in listeners) {
             listener.onSessionDisconnectClicked(mSessionPresenter!!.session!!)
@@ -50,9 +82,13 @@ class MobileActiveSessionViewMvcImpl(
         dismissBottomSheet()
     }
 
-    override fun reconnectSessionPressed() {
+    override fun onSessionReconnectClicked(session: Session) {
         for (listener in listeners) {
             listener.onSessionReconnectClicked(mSessionPresenter!!.session!!)
         }
+    }
+
+    override fun onSessionStopClicked(session: Session) {
+        stopSessionPressed()
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -27,7 +27,8 @@ class MeasurementsTableContainer {
 
     private var mSelectable: Boolean
     private var mDisplayValues: Boolean
-    private var mDisplayAvarages: Boolean = false
+    private var mDisplayAvarages = false
+    private var mDisplayDisconnectedIndicator = false
 
     private val mMeasurementStreams: MutableList<MeasurementStream> = mutableListOf()
     private val mLastMeasurementColors: HashMap<MeasurementStream, Int> = HashMap()
@@ -42,7 +43,13 @@ class MeasurementsTableContainer {
     private var mSessionPresenter: SessionPresenter? = null
     private var mOnMeasurementStreamChanged: ((MeasurementStream) -> Unit)? = null
 
-    constructor(context: Context, inflater: LayoutInflater, rootView: View?, selectable: Boolean = false, displayValues: Boolean = false) {
+    constructor(
+        context: Context,
+        inflater: LayoutInflater,
+        rootView: View?,
+        selectable: Boolean = false,
+        displayValues: Boolean = false
+    ) {
         mContext = context
         mRootView = rootView
         mLayoutInflater = inflater
@@ -90,6 +97,7 @@ class MeasurementsTableContainer {
         mSessionPresenter = sessionPresenter
         mOnMeasurementStreamChanged = onMeasurementStreamChanged
         mDisplayAvarages = mSessionPresenter?.isMobileDormant() ?: false
+        mDisplayDisconnectedIndicator = mSessionPresenter?.isMobileActive() ?: false
 
         val session = mSessionPresenter?.session
         if (session != null && session.streams.count() > 0) {
@@ -224,7 +232,7 @@ class MeasurementsTableContainer {
         val circleView = valueView.findViewById<ImageView>(R.id.circle_indicator)
         val valueTextView = valueView.findViewById<TextView>(R.id.measurement_value)
 
-        if (mSessionPresenter?.isDisconnected() == true) {
+        if (mDisplayDisconnectedIndicator && mSessionPresenter?.isDisconnected() == true) {
             valueTextView.text = "-"
             circleView.visibility = View.GONE
         } else {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -28,7 +28,6 @@ class MeasurementsTableContainer {
     private var mSelectable: Boolean
     private var mDisplayValues: Boolean
     private var mDisplayAvarages = false
-    private var mDisplayDisconnectedIndicator = false
 
     private val mMeasurementStreams: MutableList<MeasurementStream> = mutableListOf()
     private val mLastMeasurementColors: HashMap<MeasurementStream, Int> = HashMap()
@@ -97,7 +96,6 @@ class MeasurementsTableContainer {
         mSessionPresenter = sessionPresenter
         mOnMeasurementStreamChanged = onMeasurementStreamChanged
         mDisplayAvarages = mSessionPresenter?.isMobileDormant() ?: false
-        mDisplayDisconnectedIndicator = mSessionPresenter?.isMobileActive() ?: false
 
         val session = mSessionPresenter?.session
         if (session != null && session.streams.count() > 0) {
@@ -226,13 +224,17 @@ class MeasurementsTableContainer {
         }
     }
 
+    private fun shouldDisplayDisconnectedIndicator(): Boolean {
+        return mSessionPresenter?.isMobileActive() == true && mSessionPresenter?.isDisconnected() == true
+    }
+
     private fun renderValueView(measurementValue: Double, color: Int): View {
         val valueView = mLayoutInflater.inflate(R.layout.measurement_value, null, false)
 
         val circleView = valueView.findViewById<ImageView>(R.id.circle_indicator)
         val valueTextView = valueView.findViewById<TextView>(R.id.measurement_value)
 
-        if (mDisplayDisconnectedIndicator && mSessionPresenter?.isDisconnected() == true) {
+        if (shouldDisplayDisconnectedIndicator()) {
             valueTextView.text = "-"
             circleView.visibility = View.GONE
         } else {

--- a/app/src/main/res/layout/disconnected_view.xml
+++ b/app/src/main/res/layout/disconnected_view.xml
@@ -10,7 +10,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:background="@color/aircasting_blue_50"
-        android:padding="@dimen/keyline_8">
+        android:padding="@dimen/keyline_8"
+        android:visibility="gone">
 
         <TextView
             android:id="@+id/disconnected_view_bluetooth_device_header"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,10 +40,16 @@
     <string name="unfollow_button">unfollow</string>
     <string name="map_button">map</string>
     <string name="graph_button">graph</string>
+
     <string name="disconnected_view_bluetooth_device_header">Measurement device\ndisconnected</string>
     <string name="disconnected_view_bluetooth_device_description">Your measurement device is no longer connected to the AirCasting app. Make sure Bluetooth is on and your measurement device is nearby.</string>
     <string name="disconnected_view_bluetooth_device_reconnect_button">Reconnect</string>
     <string name="disconnected_view_bluetooth_device_finish_button">Finish session</string>
+
+    <string name="disconnected_view_airbeam3_header">Your AirBeam3 is now\nin stand-alone mode</string>
+    <string name="disconnected_view_airbeam3_description">AirBeam3 is now recording using its SD card. The measurements will be displayed here after syncing.</string>
+    <string name="disconnected_view_airbeam3_sync_button">Finish recording &amp; sync</string>
+    <string name="disconnected_view_airbeam3_finish_button">Finish recording &amp; don\'t sync</string>
 
     <!--  Dialogs -->
     <string name="turn_on_wifi_dialog_header">Turn on WIFI</string>


### PR DESCRIPTION
Fixes:

https://trello.com/c/w1HHV4Lq/1056-v146-fixed-following-after-configuring-an-ab3-to-record-a-fixed-session-the-measurement-device-disconnected-message-is-shown-und
and

https://trello.com/c/a5zpwHjk/1063-mobile-active-disconnect-ab3-wrong-card-displayed