### PR TITLE
Fixed: Removed go to the dashboard after following a session

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
@@ -7,7 +7,6 @@ import io.lunarlogic.aircasting.database.DatabaseProvider
 import io.lunarlogic.aircasting.events.EditSessionEvent
 import io.lunarlogic.aircasting.screens.new_session.NewSessionActivity
 import io.lunarlogic.aircasting.exceptions.ErrorHandler
-import io.lunarlogic.aircasting.lib.NavigationController
 import io.lunarlogic.aircasting.lib.Settings
 import io.lunarlogic.aircasting.networking.services.ApiServiceFactory
 import io.lunarlogic.aircasting.networking.services.DownloadMeasurementsService
@@ -67,7 +66,6 @@ abstract class SessionsController(
 
     override fun onFollowButtonClicked(session: Session) {
         updateFollowedAt(session)
-        NavigationController.goToDashboard(DashboardPagerAdapter.FOLLOWING_TAB_INDEX)
     }
 
     override fun onUnfollowButtonClicked(session: Session) {


### PR DESCRIPTION
Basically it's a one-line change - I removed line that navigated to the dashboard after following a session.
[https://trello.com/c/btcWyfNw/1031-fixed-after-following-a-session-stay-on-fixed-tab](url)