### PR TITLE
Fixed test - fixed session

### DIFF
--- a/app/src/androidTest/java/io/lunarlogic/aircasting/FixedSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/FixedSessionTest.kt
@@ -271,6 +271,6 @@ class FixedSessionTest {
         Thread.sleep(1000)
         onView(withId(R.id.unfollow_button)).perform(click())
         Thread.sleep(2000)
-        onView(withText("New session to follow")).check(matches(not(isDisplayed())))
+        onView(withText("New session to follow")).check(matches(isDisplayed()))
     }
 }


### PR DESCRIPTION
I'm not sure why this test was checking if session wasn't displayed? As far as I understand view with session title "New session to follow" should be visible on `FIXED_TAB_INDEX` tab, but not on `FOLLOWING_TAB_INDEX` tab, correct me if I'm wrong.