### PR TITLE
Fix chart swapping

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
-        versionName "1.50"
+        versionName "1.54"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // Read the API key from ./secure.properties into R.string.maps_api_key

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionPresenter.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionPresenter.kt
@@ -32,7 +32,9 @@ class SessionPresenter() {
         this.expanded = expanded
         this.loading = loading
         this.sensorThresholds = sensorThresholds
-        this.chartData = ChartData(session) // TODO load this only on certain tabs??
+        if (session.tab == SessionsTab.FOLLOWING || session.tab == SessionsTab.MOBILE_ACTIVE) {
+            this.chartData = ChartData(session)
+        }
     }
 
     constructor(sessionUUID: String, initialSensorName: String?): this() {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -191,10 +191,10 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         mMeasurementsTableContainer.bindSession(mSessionPresenter, this::onMeasurementStreamChanged)
     }
 
-    private fun bindChartData(streamChanged: Boolean = false) {
+    private fun bindChartData() {
         if (!showChart()) return
 
-        mChart.bindChart(mSessionPresenter, streamChanged)
+        mChart.bindChart(mSessionPresenter)
     }
 
     protected open fun bindFollowButtons(sessionPresenter: SessionPresenter) {
@@ -252,7 +252,7 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
 
     protected fun onMeasurementStreamChanged(measurementStream: MeasurementStream) {
         mSessionPresenter?.selectedStream = measurementStream
-        bindChartData(true)
+        bindChartData()
     }
 
     private fun onFollowButtonClicked() {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/charts/Chart.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/charts/Chart.kt
@@ -13,7 +13,6 @@ import io.lunarlogic.aircasting.R
 import io.lunarlogic.aircasting.lib.MeasurementColor
 import io.lunarlogic.aircasting.screens.dashboard.SessionPresenter
 import kotlinx.android.synthetic.main.expanded_session_view.view.*
-import java.sql.Timestamp
 
 
 class Chart {
@@ -29,8 +28,6 @@ class Chart {
     private var mDataSet: LineDataSet? = null
     private var mSessionPresenter: SessionPresenter? = null
 
-    private var mChartRefreshService: ChartRefreshService
-
     constructor(
         context: Context,
         rootView: View?
@@ -42,27 +39,21 @@ class Chart {
         mChartStartTimeTextView = mRootView?.chart_start_time
         mChartEndTimeTextView = mRootView?.chart_end_time
         mChartUnitTextView = mRootView?.chart_unit
-
-        mChartRefreshService = ChartRefreshService(mSessionPresenter?.session)
     }
 
     fun bindChart(
-        sessionPresenter: SessionPresenter?,
-        streamChanged: Boolean = false
+        sessionPresenter: SessionPresenter?
     ) {
         val session = sessionPresenter?.session
         mSessionPresenter = sessionPresenter
 
-        if(streamChanged || mChartRefreshService.shouldBeRefreshed()) {
             setEntries(sessionPresenter)
 
             if (session != null && session?.streams.count() > 0) {
                 resetChart()
-                mChartRefreshService.setLastRefreshTime()
                 mDataSet = prepareDataSet()
                 drawChart()
             }
-        }
         setTimesAndUnit()
     }
 


### PR DESCRIPTION
1. Fixing issue https://trello.com/c/OJuxpAsN/1090-following-charts-are-swapped-between-sessions

Chart was only refreshed every minute, so it was being recycled if you scrolled. However, I think we can just calculate data every minute to achieve the desired effect and refresh the chart on every bindSession (so I did it like this now).

2. As I was touching charts, I introduced conditional initializing chartData in session presenter (not needed in dormant/fixed tabs).