### PR TITLE
Bottom navigation icon sizes

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,6 +30,7 @@
         android:layout_marginStart="0dp"
         android:layout_marginEnd="0dp"
         android:background="?android:attr/windowBackground"
+        app:itemIconSize="@dimen/bottom_navigation_icon_size"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,7 +30,7 @@
         android:layout_marginStart="0dp"
         android:layout_marginEnd="0dp"
         android:background="?android:attr/windowBackground"
-        app:itemIconSize="@dimen/bottom_navigation_icon_size"
+        app:itemIconSize="@dimen/keyline_7"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/layout/expanded_session_view.xml
+++ b/app/src/main/res/layout/expanded_session_view.xml
@@ -16,8 +16,7 @@
             android:id="@+id/chart_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:minHeight="100dp"
-            />
+            android:minHeight="100dp" />
         <TextView
             android:id="@+id/chart_start_time"
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -39,6 +39,7 @@
     <dimen name="keyline_4">16dp</dimen>
     <dimen name="keyline_5">20dp</dimen>
     <dimen name="keyline_6">24dp</dimen>
+    <dimen name="keyline_7">28dp</dimen>
     <dimen name="keyline_8">32dp</dimen>
     <dimen name="keyline_10">40dp</dimen>
     <dimen name="keyline_12">64dp</dimen>
@@ -48,5 +49,5 @@
     <dimen name="map_height">300dp</dimen>
     <dimen name="hlu_slider_thumb_radius">10dp</dimen>
 
-    <dimen name ="bottom_navigation_icon_size">32dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -48,6 +48,4 @@
 
     <dimen name="map_height">300dp</dimen>
     <dimen name="hlu_slider_thumb_radius">10dp</dimen>
-
-
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -47,4 +47,6 @@
 
     <dimen name="map_height">300dp</dimen>
     <dimen name="hlu_slider_thumb_radius">10dp</dimen>
+
+    <dimen name ="bottom_navigation_icon_size">32dp</dimen>
 </resources>


### PR DESCRIPTION
I guess we should talk about it. For now these icons look a bit tough I think. 
Probably, the problem is we have only 24dp and 32 dp sizes available (styling in a good manner)- 24dp (current) is too small and 32 dp is huuuuge.