### PR TITLE
Disable the option for creating fixed session when no internet connection

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/fixed/FixedController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/fixed/FixedController.kt
@@ -1,6 +1,7 @@
 package io.lunarlogic.aircasting.screens.dashboard.fixed
 
 import android.content.Context
+import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
@@ -12,6 +13,7 @@ import io.lunarlogic.aircasting.models.SessionsViewModel
 import io.lunarlogic.aircasting.screens.dashboard.SessionsViewMvc
 import io.lunarlogic.aircasting.models.Session
 import io.lunarlogic.aircasting.networking.services.ApiServiceFactory
+import io.lunarlogic.aircasting.networking.services.ConnectivityManager
 import io.lunarlogic.aircasting.screens.dashboard.EditSessionBottomSheet
 import org.greenrobot.eventbus.EventBus
 
@@ -38,6 +40,11 @@ class FixedController(
     }
 
     override fun onRecordNewSessionClicked() {
+        if (!ConnectivityManager.isConnected(mContext)){
+            Toast.makeText(mContext, "You need to have internet connection to create fixed session", Toast.LENGTH_LONG).show()
+            return
+        }
+
         startNewSession(Session.Type.FIXED)
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/fixed/FixedController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/fixed/FixedController.kt
@@ -5,6 +5,7 @@ import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
+import io.lunarlogic.aircasting.R
 import io.lunarlogic.aircasting.events.DeleteSessionEvent
 import io.lunarlogic.aircasting.lib.Settings
 import io.lunarlogic.aircasting.models.observers.DormantSessionsObserver
@@ -40,8 +41,8 @@ class FixedController(
     }
 
     override fun onRecordNewSessionClicked() {
-        if (!ConnectivityManager.isConnected(mContext)){
-            Toast.makeText(mContext, "You need to have internet connection to create fixed session", Toast.LENGTH_LONG).show()
+        if (!ConnectivityManager.isConnected(mContext)) {
+            Toast.makeText(mContext, mContext?.getString(R.string.fixed_session_no_internet_connection), Toast.LENGTH_LONG).show()
             return
         }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/following/FollowingController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/following/FollowingController.kt
@@ -1,6 +1,7 @@
 package io.lunarlogic.aircasting.screens.dashboard.following
 
 import android.content.Context
+import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
@@ -11,6 +12,7 @@ import io.lunarlogic.aircasting.models.SessionsViewModel
 import io.lunarlogic.aircasting.screens.dashboard.SessionsViewMvc
 import io.lunarlogic.aircasting.models.Session
 import io.lunarlogic.aircasting.networking.services.ApiServiceFactory
+import io.lunarlogic.aircasting.networking.services.ConnectivityManager
 
 class FollowingController(
     mRootActivity: FragmentActivity?,
@@ -34,6 +36,11 @@ class FollowingController(
     }
 
     override fun onRecordNewSessionClicked() {
+        if (!ConnectivityManager.isConnected(mContext)){
+            Toast.makeText(mContext, "You need to have internet connection to create fixed session", Toast.LENGTH_LONG).show()
+            return
+        }
+
         startNewSession(Session.Type.FIXED)
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/following/FollowingController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/following/FollowingController.kt
@@ -5,6 +5,7 @@ import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
+import io.lunarlogic.aircasting.R
 import io.lunarlogic.aircasting.lib.Settings
 import io.lunarlogic.aircasting.models.observers.ActiveSessionsObserver
 import io.lunarlogic.aircasting.screens.dashboard.SessionsController
@@ -36,8 +37,8 @@ class FollowingController(
     }
 
     override fun onRecordNewSessionClicked() {
-        if (!ConnectivityManager.isConnected(mContext)){
-            Toast.makeText(mContext, "You need to have internet connection to create fixed session", Toast.LENGTH_LONG).show()
+        if (!ConnectivityManager.isConnected(mContext)) {
+            Toast.makeText(mContext, mContext?.getString(R.string.fixed_session_no_internet_connection), Toast.LENGTH_LONG).show()
             return
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,5 +243,6 @@
     <string name="microphone_settings">Microphone settings</string>
     <string name="reset_email_sent">An email with further instructions has been sent</string>
     <string name="unknown_error">Unknown error</string>
+    <string name="fixed_session_no_internet_connection">You need to have internet connection to create fixed session</string>
 
 </resources>


### PR DESCRIPTION
https://trello.com/c/UnyADYc8/1098-disable-the-option-for-creating-a-fixed-session-if-you-dont-have-internet-connection-display-the-error-message