### PR TITLE
Smaller map graph follow unfollow buttons

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -1,10 +1,13 @@
 package io.lunarlogic.aircasting.screens.dashboard
 
+import android.graphics.Rect
 import android.view.LayoutInflater
+import android.view.TouchDelegate
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.FragmentManager
@@ -43,6 +46,11 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
     private var mMapButton: Button
     private var mGraphButton: Button
     private var mLoader: ImageView?
+
+    private var mFollowTouchableArea: LinearLayout
+    private var mUnfollowTouchableArea: LinearLayout
+    private var mMapTouchableArea: LinearLayout
+    private var mGraphTouchableArea: LinearLayout
 
     protected var mSessionPresenter: SessionPresenter? = null
 
@@ -91,25 +99,34 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
             onCollapseSessionCardClicked()
             collapseSessionCard()
         }
+
         mFollowButton = findViewById(R.id.follow_button)
+        mFollowTouchableArea = findViewById(R.id.follow_container)
         mFollowButton.setOnClickListener {
             onFollowButtonClicked()
         }
+        expandViewHitArea(mFollowTouchableArea, mFollowButton)
 
         mUnfollowButton = findViewById(R.id.unfollow_button)
+        mUnfollowTouchableArea = findViewById(R.id.unfollow_container)
         mUnfollowButton.setOnClickListener {
             onUnfollowButtonClicked()
         }
+        expandViewHitArea(mUnfollowTouchableArea, mUnfollowButton)
 
         mMapButton = findViewById(R.id.map_button)
+        mMapTouchableArea = findViewById(R.id.map_container)
         mMapButton.setOnClickListener {
             onMapButtonClicked()
         }
+        expandViewHitArea(mMapTouchableArea, mMapButton)
 
         mGraphButton = findViewById(R.id.graph_button)
+        mGraphTouchableArea = findViewById(R.id.graph_container)
         mGraphButton.setOnClickListener {
             onGraphButtonClicked()
         }
+        expandViewHitArea(mGraphTouchableArea, mGraphButton)
 
         mActionsButton.setOnClickListener {
             actionsButtonClicked()
@@ -311,5 +328,21 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
 
     private fun onCollapseSessionCardClicked() {
         mSessionPresenter?.expanded = false
+    }
+
+    private fun expandViewHitArea(parent : View, child : View) {
+        parent.post {
+            val parentRect = Rect()
+            val childRect = Rect()
+            parent.getHitRect(parentRect)
+            child.getHitRect(childRect)
+
+            childRect.left = parentRect.width()
+            childRect.top = parentRect.width()
+            childRect.right = parentRect.width()
+            childRect.bottom = parentRect.height()
+
+            parent.touchDelegate = TouchDelegate(childRect, child)
+        }
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
-import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.FragmentManager
@@ -46,11 +45,6 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
     private var mMapButton: Button
     private var mGraphButton: Button
     private var mLoader: ImageView?
-
-    private var mFollowTouchableArea: LinearLayout
-    private var mUnfollowTouchableArea: LinearLayout
-    private var mMapTouchableArea: LinearLayout
-    private var mGraphTouchableArea: LinearLayout
 
     protected var mSessionPresenter: SessionPresenter? = null
 
@@ -101,32 +95,28 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         }
 
         mFollowButton = findViewById(R.id.follow_button)
-        mFollowTouchableArea = findViewById(R.id.follow_container)
         mFollowButton.setOnClickListener {
             onFollowButtonClicked()
         }
-        expandViewHitArea(mFollowTouchableArea, mFollowButton)
+        expandViewHitArea(mExpandedSessionView, mFollowButton)
 
         mUnfollowButton = findViewById(R.id.unfollow_button)
-        mUnfollowTouchableArea = findViewById(R.id.unfollow_container)
         mUnfollowButton.setOnClickListener {
             onUnfollowButtonClicked()
         }
-        expandViewHitArea(mUnfollowTouchableArea, mUnfollowButton)
+        expandViewHitArea(mExpandedSessionView, mUnfollowButton)
 
         mMapButton = findViewById(R.id.map_button)
-        mMapTouchableArea = findViewById(R.id.map_container)
         mMapButton.setOnClickListener {
             onMapButtonClicked()
         }
-        expandViewHitArea(mMapTouchableArea, mMapButton)
+        expandViewHitArea(mExpandedSessionView, mMapButton)
 
         mGraphButton = findViewById(R.id.graph_button)
-        mGraphTouchableArea = findViewById(R.id.graph_container)
         mGraphButton.setOnClickListener {
             onGraphButtonClicked()
         }
-        expandViewHitArea(mGraphTouchableArea, mGraphButton)
+        expandViewHitArea(mExpandedSessionView, mGraphButton)
 
         mActionsButton.setOnClickListener {
             actionsButtonClicked()
@@ -330,19 +320,18 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         mSessionPresenter?.expanded = false
     }
 
-    private fun expandViewHitArea(parent : View, child : View) {
-        parent.post {
-            val parentRect = Rect()
-            val childRect = Rect()
-            parent.getHitRect(parentRect)
-            child.getHitRect(childRect)
+    private fun expandViewHitArea(container : View, child : View) {
+        val padding = 4
+        container.post {
+            val rect = Rect()
+            child.getHitRect(rect)
 
-            childRect.left = parentRect.width()
-            childRect.top = parentRect.width()
-            childRect.right = parentRect.width()
-            childRect.bottom = parentRect.height()
+            rect.left -= padding
+            rect.top -= padding
+            rect.right += padding
+            rect.bottom += padding
 
-            parent.touchDelegate = TouchDelegate(childRect, child)
+            container.touchDelegate = TouchDelegate(rect, child)
         }
     }
 }

--- a/app/src/main/res/layout/expanded_session_view.xml
+++ b/app/src/main/res/layout/expanded_session_view.xml
@@ -41,43 +41,80 @@
             app:layout_constraintTop_toBottomOf="@id/chart_end_time" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <Button
-        style="@style/Widget.Aircasting.ExpandedCardButtons"
-        android:id="@+id/follow_button"
+    <LinearLayout
+        android:id="@+id/follow_container"
+        app:layout_constraintTop_toBottomOf="@id/chart_container"
+        app:layout_constraintStart_toStartOf="parent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/follow_button"
-        android:backgroundTint="@color/aircasting_blue_400"
-        android:textColor="@color/aircasting_white"
-        app:layout_constraintTop_toBottomOf="@id/chart_container"
-        app:layout_constraintStart_toStartOf="parent" />
+        android:orientation="horizontal">
+        <Button
+            style="@style/Widget.Aircasting.ExpandedCardButtons"
+            android:id="@+id/follow_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/follow_button"
+            android:minHeight="@dimen/height_0"
+            android:layout_marginTop="@dimen/margin_top_5"
+            android:backgroundTint="@color/aircasting_blue_400"
+            android:textColor="@color/aircasting_white" />
+    </LinearLayout>
 
-    <Button
-        style="@style/Widget.Aircasting.ExpandedCardButtonUnfollow"
-        android:id="@+id/unfollow_button"
+    <LinearLayout
+        android:id="@+id/unfollow_container"
+        app:layout_constraintTop_toBottomOf="@id/chart_container"
+        app:layout_constraintStart_toStartOf="parent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/unfollow_button"
-        android:visibility="gone"
-        app:layout_constraintTop_toBottomOf="@id/chart_container"
-        app:layout_constraintStart_toStartOf="parent" />
+        android:layout_marginEnd="50dp"
+        android:orientation="horizontal">
+        <Button
+            style="@style/Widget.Aircasting.ExpandedCardButtonUnfollow"
+            android:id="@+id/unfollow_button"
+            android:text="@string/unfollow_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="@dimen/height_0"
+            android:layout_marginTop="@dimen/margin_top_5"
+            android:visibility="gone">
+        </Button>
 
-    <Button
-        style="@style/Widget.Aircasting.ExpandedCardButtons"
-        android:id="@+id/map_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/map_button"
-        android:layout_marginEnd="@dimen/keyline_2"
-        app:layout_constraintTop_toBottomOf="@id/chart_container"
-        app:layout_constraintEnd_toStartOf="@id/graph_button" />
+    </LinearLayout>
 
-    <Button
-        style="@style/Widget.Aircasting.ExpandedCardButtons"
-        android:id="@+id/graph_button"
+    <LinearLayout
+        android:id="@+id/map_container"
+        app:layout_constraintTop_toBottomOf="@id/chart_container"
+        app:layout_constraintEnd_toStartOf="@id/graph_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/graph_button"
+        android:orientation="horizontal">
+
+        <Button
+            style="@style/Widget.Aircasting.ExpandedCardButtons"
+            android:id="@+id/map_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/map_button"
+            android:minHeight="@dimen/height_0"
+            android:layout_marginTop="@dimen/margin_top_5"
+            android:layout_marginEnd="@dimen/keyline_2" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/graph_container"
         app:layout_constraintTop_toBottomOf="@id/chart_container"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            style="@style/Widget.Aircasting.ExpandedCardButtons"
+            android:id="@+id/graph_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="@dimen/height_0"
+            android:layout_marginTop="@dimen/margin_top_5"
+            android:text="@string/graph_button" />
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/expanded_session_view.xml
+++ b/app/src/main/res/layout/expanded_session_view.xml
@@ -41,80 +41,52 @@
             app:layout_constraintTop_toBottomOf="@id/chart_end_time" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <LinearLayout
-        android:id="@+id/follow_container"
-        app:layout_constraintTop_toBottomOf="@id/chart_container"
-        app:layout_constraintStart_toStartOf="parent"
+    <Button
+        style="@style/Widget.Aircasting.ExpandedCardButtons"
+        android:id="@+id/follow_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
-        <Button
-            style="@style/Widget.Aircasting.ExpandedCardButtons"
-            android:id="@+id/follow_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/follow_button"
-            android:minHeight="@dimen/height_0"
-            android:layout_marginTop="@dimen/margin_top_5"
-            android:backgroundTint="@color/aircasting_blue_400"
-            android:textColor="@color/aircasting_white" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/unfollow_container"
+        android:text="@string/follow_button"
+        android:minHeight="0dp"
+        android:layout_marginTop="5dp"
+        android:backgroundTint="@color/aircasting_blue_400"
+        android:textColor="@color/aircasting_white"
         app:layout_constraintTop_toBottomOf="@id/chart_container"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        style="@style/Widget.Aircasting.ExpandedCardButtonUnfollow"
+        android:id="@+id/unfollow_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="50dp"
-        android:orientation="horizontal">
-        <Button
-            style="@style/Widget.Aircasting.ExpandedCardButtonUnfollow"
-            android:id="@+id/unfollow_button"
-            android:text="@string/unfollow_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:minHeight="@dimen/height_0"
-            android:layout_marginTop="@dimen/margin_top_5"
-            android:visibility="gone">
-        </Button>
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/map_container"
+        android:text="@string/unfollow_button"
+        android:minHeight="0dp"
+        android:layout_marginTop="5dp"
+        android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@id/chart_container"
-        app:layout_constraintEnd_toStartOf="@id/graph_container"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        style="@style/Widget.Aircasting.ExpandedCardButtons"
+        android:id="@+id/map_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <Button
-            style="@style/Widget.Aircasting.ExpandedCardButtons"
-            android:id="@+id/map_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/map_button"
-            android:minHeight="@dimen/height_0"
-            android:layout_marginTop="@dimen/margin_top_5"
-            android:layout_marginEnd="@dimen/keyline_2" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/graph_container"
+        android:text="@string/map_button"
+        android:minHeight="0dp"
+        android:layout_marginTop="5dp"
+        android:layout_marginEnd="@dimen/keyline_2"
         app:layout_constraintTop_toBottomOf="@id/chart_container"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/graph_button" />
+
+    <Button
+        style="@style/Widget.Aircasting.ExpandedCardButtons"
+        android:id="@+id/graph_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:text="@string/graph_button"
+        android:minHeight="0dp"
+        android:layout_marginTop="5dp"
+        app:layout_constraintTop_toBottomOf="@id/chart_container"
+        app:layout_constraintEnd_toEndOf="parent" />
 
-        <Button
-            style="@style/Widget.Aircasting.ExpandedCardButtons"
-            android:id="@+id/graph_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:minHeight="@dimen/height_0"
-            android:layout_marginTop="@dimen/margin_top_5"
-            android:text="@string/graph_button" />
-    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -46,10 +46,6 @@
 
     <dimen name="card_corner_radius">0dp</dimen>
 
-    <dimen name="height_0">0dp</dimen>
-    <dimen name="padding_2">2dp</dimen>
-    <dimen name="margin_top_5">5dp</dimen>
-
     <dimen name="map_height">300dp</dimen>
     <dimen name="hlu_slider_thumb_radius">10dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -46,6 +46,10 @@
 
     <dimen name="card_corner_radius">0dp</dimen>
 
+    <dimen name="height_0">0dp</dimen>
+    <dimen name="padding_2">2dp</dimen>
+    <dimen name="margin_top_5">5dp</dimen>
+
     <dimen name="map_height">300dp</dimen>
     <dimen name="hlu_slider_thumb_radius">10dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -343,7 +343,7 @@
         <item name="android:textColor">@color/aircasting_blue_400</item>
         <item name="android:textSize">@dimen/text_size_xs</item>
         <item name="android:textAlignment">center</item>
-        <item name="android:padding">@dimen/keyline_2</item>
+        <item name="android:padding">@dimen/padding_2</item>
         <item name="android:textAllCaps">false</item>
         <item name="fontFamily">@font/muli_semi_bold</item>
         <item name="android:fontFamily">@font/muli_semi_bold</item>
@@ -354,7 +354,7 @@
         <item name="android:translationX">0dp</item>
         <item name="android:translationY">0dp</item>
         <item name="android:translationZ">0dp</item>
-        <item name="android:padding">@dimen/keyline_2</item>
+        <item name="android:padding">@dimen/padding_2</item>
         <item name="android:textColor">@color/aircasting_blue_400</item>
         <item name="android:textSize">@dimen/text_size_xs</item>
         <item name="android:textAlignment">center</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -343,7 +343,7 @@
         <item name="android:textColor">@color/aircasting_blue_400</item>
         <item name="android:textSize">@dimen/text_size_xs</item>
         <item name="android:textAlignment">center</item>
-        <item name="android:padding">@dimen/padding_2</item>
+        <item name="android:padding">2dp</item>
         <item name="android:textAllCaps">false</item>
         <item name="fontFamily">@font/muli_semi_bold</item>
         <item name="android:fontFamily">@font/muli_semi_bold</item>
@@ -354,7 +354,7 @@
         <item name="android:translationX">0dp</item>
         <item name="android:translationY">0dp</item>
         <item name="android:translationZ">0dp</item>
-        <item name="android:padding">@dimen/padding_2</item>
+        <item name="android:padding">2dp</item>
         <item name="android:textColor">@color/aircasting_blue_400</item>
         <item name="android:textSize">@dimen/text_size_xs</item>
         <item name="android:textAlignment">center</item>


### PR DESCRIPTION
Important changes:

- I've changed paddings and dimens for `follow`, `unfollow`, `map`, `graphs` buttons
- I've added containers for buttons
- I used TouchDelegate to keep the touchable area the same as earlier 

<img width="299" alt="Screenshot 2021-02-03 at 19 18 39" src="https://user-images.githubusercontent.com/23139274/106791448-34dbb780-6655-11eb-993c-98c54df5400e.png">

AC:

- [x] it matches proto: https://projects.invisionapp.com/share/DCWT9W6BUE7#/screens/414476845
- [ ] touchable area is the same

[TouchDelegate docs](https://developer.android.com/reference/android/view/TouchDelegate.html)

[ticket](https://trello.com/c/3fb7fnUc/1070-cards-map-graph-follow-buttons-should-match-the-proto)