### PR TITLE
Fixed unfollow button state

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -353,10 +353,11 @@
 
     <style name="Widget.Aircasting.ExpandedCardButtonUnfollow" parent="@style/Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:translationX">0dp</item>
+        <item name="android:backgroundTint">@color/aircasting_white</item>
+        <item name="android:textColor">@color/aircasting_blue_400</item>
         <item name="android:translationY">0dp</item>
         <item name="android:translationZ">0dp</item>
         <item name="android:padding">2dp</item>
-        <item name="android:textColor">@color/aircasting_blue_400</item>
         <item name="android:textSize">@dimen/text_size_xs</item>
         <item name="android:textAlignment">center</item>
         <item name="android:textAllCaps">false</item>


### PR DESCRIPTION
I've changed the background tint for `unfollow` button 🐛 
<img width="296" alt="Screenshot 2021-02-09 at 20 29 29" src="https://user-images.githubusercontent.com/23139274/107417243-a912d100-6b15-11eb-81c4-3e0abedaeea0.png">
[ticket](https://trello.com/c/H2x9lI9w/1131-fixed-following-unfollow-button-in-wrong-state)