### PR TITLE
Moved chart label

### DIFF
--- a/app/src/main/res/layout/expanded_session_view.xml
+++ b/app/src/main/res/layout/expanded_session_view.xml
@@ -35,10 +35,10 @@
             android:id="@+id/chart_unit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            app:layout_constraintBaseline_toBaselineOf="@id/chart_start_time"
             android:textAppearance="@style/TextAppearance.Aircasting.ChartLabels"
-            android:layout_marginTop="@dimen/keyline_2"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/chart_end_time" />
+            app:layout_constraintEnd_toStartOf="@id/chart_end_time"
+            app:layout_constraintStart_toEndOf="@id/chart_start_time" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <Button


### PR DESCRIPTION
I've moved the label so it sits between the beginning and end times for the chart:

<img width="324" alt="Android Emulator - Pixel_2_API_28:5554 2021-02-11 12-00-43" src="https://user-images.githubusercontent.com/23139274/107628406-dddf6f00-6c60-11eb-8908-377cfe21306c.png">
