### PR TITLE
Display name for a bluetooth device should be the same as in Settings -> Bluetooth

### DIFF
--- a/app/src/androidTest/java/io/lunarlogic/aircasting/FixedSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/FixedSessionTest.kt
@@ -107,7 +107,6 @@ class FixedSessionTest {
 
         whenever(bluetoothManager.isBluetoothEnabled()).thenReturn(true)
         whenever(permissionsManager.locationPermissionsGranted(any())).thenReturn(true)
-        val airBeamAddress = FakeDeviceItem.ADDRESS
         stubPairedDevice(bluetoothManager)
 
         testRule.launchActivity(null)
@@ -119,7 +118,7 @@ class FixedSessionTest {
 
         onView(withId(R.id.turn_on_airbeam_ready_button)).perform(click())
 
-        onView(withText(containsString(airBeamAddress))).perform(click())
+        onView(withText(containsString(FakeDeviceItem.NAME))).perform(click())
 
         onView(withId(R.id.connect_button)).perform(click())
         Thread.sleep(4000)
@@ -170,7 +169,6 @@ class FixedSessionTest {
 
         whenever(bluetoothManager.isBluetoothEnabled()).thenReturn(true)
         whenever(permissionsManager.locationPermissionsGranted(any())).thenReturn(true)
-        val airBeamAddress = FakeDeviceItem.ADDRESS
         stubPairedDevice(bluetoothManager)
 
         testRule.launchActivity(null)
@@ -182,7 +180,7 @@ class FixedSessionTest {
 
         onView(withId(R.id.turn_on_airbeam_ready_button)).perform(click())
 
-        onView(withText(containsString(airBeamAddress))).perform(click())
+        onView(withText(containsString(FakeDeviceItem.NAME))).perform(click())
 
         onView(withId(R.id.connect_button)).perform(click())
         Thread.sleep(4000)

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
@@ -94,7 +94,6 @@ class MobileSessionTest {
 
         whenever(bluetoothManager.isBluetoothEnabled()).thenReturn(true)
         whenever(permissionsManager.locationPermissionsGranted(any())).thenReturn(true)
-        val airBeamAddress = FakeDeviceItem.ADDRESS
         stubPairedDevice(bluetoothManager)
 
         testRule.launchActivity(null)
@@ -106,7 +105,7 @@ class MobileSessionTest {
         onView(withId(R.id.select_device_type_bluetooth_card)).perform(click())
 
         onView(withId(R.id.turn_on_airbeam_ready_button)).perform(click())
-        onView(withText(containsString(airBeamAddress))).perform(click())
+        onView(withText(containsString(FakeDeviceItem.NAME))).perform(click())
 
         onView(withId(R.id.connect_button)).perform(click())
         Thread.sleep(4000)

--- a/app/src/androidTest/java/io/lunarlogic/aircasting/helpers/SensorHelpers.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/helpers/SensorHelpers.kt
@@ -8,7 +8,7 @@ import org.mockito.Mockito
 class FakeDeviceItem {
     companion object {
         val ID = "0018961070D6"
-        val NAME = "AirBeam2"
+        val NAME = "AirBeam2:0018961070D6"
         val ADDRESS = "00:18:96:10:70:D6"
         val TYPE = DeviceItem.Type.AIRBEAM2
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/select_device/DeviceItem.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/select_device/DeviceItem.kt
@@ -38,14 +38,6 @@ open class DeviceItem(private val mBluetoothDevice: BluetoothDevice? = null) : P
 
     val bluetoothDevice get() = mBluetoothDevice
 
-    fun displayName(): String {
-        if (isAirBeam()) {
-            return name.split(":", "-").first()
-        }
-
-        return name
-    }
-
     fun isAirBeam(): Boolean {
         return arrayOf(Type.AIRBEAM1, Type.AIRBEAM2, Type.AIRBEAM3).contains(type)
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/select_device/SelectDeviceViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/select_device/SelectDeviceViewMvcImpl.kt
@@ -69,7 +69,7 @@ class SelectDeviceViewMvcImpl: BaseObservableViewMvc<SelectDeviceViewMvc.Listene
             } else {
                 viewHolder.itemView.radio.setImageResource(R.drawable.ic_radio)
             }
-            viewHolder.itemView.label.text = "${deviceItem.displayName()} ${deviceItem.address}"
+            viewHolder.itemView.label.text = "${deviceItem.name}"
         }
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/AirBeamSyncService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/AirBeamSyncService.kt
@@ -131,7 +131,7 @@ class AirBeamSyncService: SensorService(),
     }
 
     override fun onConnectionSuccessful(deviceItem: DeviceItem, sessionUUID: String?) {
-        showInfo("Connection to ${deviceItem.displayName()} successful.")
+        showInfo("Connection to ${deviceItem.name} successful.")
 
         if (clearSDCard) {
             mAirBeamConnector?.clearSDCard()
@@ -142,7 +142,7 @@ class AirBeamSyncService: SensorService(),
 
     override fun onConnectionFailed(deviceId: String) {
         // TODO: temporary thing
-        showInfo("Connection to ${mDeviceItem?.displayName()} failed.")
+        showInfo("Connection to ${mDeviceItem?.name} failed.")
     }
 
     override fun onDisconnect(deviceId: String) {


### PR DESCRIPTION
[Task](https://trello.com/c/1aTwHQFB/1037-change-the-app-to-use-the-esp32-device-name-rather-than-the-ble-mac-address)