### PR TITLE
Session details - gain more vertical space for map & graph

### DIFF
--- a/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
@@ -173,7 +173,7 @@ class MobileSessionTest {
         openMap()
         Thread.sleep(3000)
 
-        onView(withId(R.id.more_button)).perform(click())
+        onView(withId(R.id.more_invisible_button)).perform(click())
         onView(isRoot()).perform(swipeUp())
         onView(withId(R.id.reset_button)).perform(click())
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/lib/TouchDelegateComposite.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/lib/TouchDelegateComposite.kt
@@ -1,0 +1,33 @@
+package io.lunarlogic.aircasting.lib
+
+import android.graphics.Rect
+import android.view.MotionEvent
+import android.view.TouchDelegate
+import android.view.View
+
+
+class TouchDelegateComposite(view: View?) : TouchDelegate(emptyRect, view) {
+    private val delegates: MutableList<TouchDelegate> =
+        ArrayList()
+
+    fun addDelegate(delegate: TouchDelegate?) {
+        if (delegate != null) {
+            delegates.add(delegate)
+        }
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        var res = false
+        val x = event.x
+        val y = event.y
+        for (delegate in delegates) {
+            event.setLocation(x, y)
+            res = delegate.onTouchEvent(event) || res
+        }
+        return res
+    }
+
+    companion object {
+        private val emptyRect: Rect = Rect()
+    }
+}

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -218,7 +218,7 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         }
         bindExpandedMeasurementsDesctription()
 
-        mSessionCardLayout.setPadding(mSessionCardLayout.paddingLeft, mSessionCardLayout.paddingTop, mSessionCardLayout.paddingRight, 0)
+        adjustSessionCardPadding()
 
         expandButtonsHitAreas(listOf(mGraphButton, mMapButton, mUnfollowButton, mFollowButton), mExpandedSessionView)
     }
@@ -230,7 +230,7 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         mMeasurementsTableContainer.makeStatic(showMeasurementsTableValues())
         bindCollapsedMeasurementsDesctription()
 
-        mSessionCardLayout.setPadding(mSessionCardLayout.paddingLeft, mSessionCardLayout.paddingTop, mSessionCardLayout.paddingRight, mSessionCardLayout.paddingRight)
+        adjustSessionCardPadding()
     }
 
     protected fun setExpandCollapseButton() {
@@ -346,6 +346,30 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
 
         parentView.post {
             parentView.touchDelegate = touchDelegateComposite
+        }
+    }
+
+    /**
+     * In order to really increase extended card buttons' touch area
+     * we need to make expanded_session_view container bigger
+     * by increasing bottom padding. We need to remove session card padding
+     * when the card is expanded and add it back when it is collapsed
+     */
+    private fun adjustSessionCardPadding() {
+        if (mSessionPresenter?.expanded == true) {
+            mSessionCardLayout.setPadding(
+                mSessionCardLayout.paddingLeft,
+                mSessionCardLayout.paddingTop,
+                mSessionCardLayout.paddingRight,
+                0
+            )
+        } else {
+            mSessionCardLayout.setPadding(
+                mSessionCardLayout.paddingLeft,
+                mSessionCardLayout.paddingTop,
+                mSessionCardLayout.paddingRight,
+                mSessionCardLayout.paddingRight
+            )
         }
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -12,11 +12,12 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.FragmentManager
 import io.lunarlogic.aircasting.R
 import io.lunarlogic.aircasting.lib.AnimatedLoader
+import io.lunarlogic.aircasting.lib.TouchDelegateComposite
+import io.lunarlogic.aircasting.models.MeasurementStream
 import io.lunarlogic.aircasting.screens.common.BaseObservableViewMvc
 import io.lunarlogic.aircasting.screens.common.BottomSheet
-import io.lunarlogic.aircasting.screens.session_view.MeasurementsTableContainer
 import io.lunarlogic.aircasting.screens.dashboard.charts.Chart
-import io.lunarlogic.aircasting.models.MeasurementStream
+import io.lunarlogic.aircasting.screens.session_view.MeasurementsTableContainer
 import kotlinx.android.synthetic.main.expanded_session_view.view.*
 
 abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerType>,
@@ -98,25 +99,21 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         mFollowButton.setOnClickListener {
             onFollowButtonClicked()
         }
-        expandViewHitArea(mExpandedSessionView, mFollowButton)
 
         mUnfollowButton = findViewById(R.id.unfollow_button)
         mUnfollowButton.setOnClickListener {
             onUnfollowButtonClicked()
         }
-        expandViewHitArea(mExpandedSessionView, mUnfollowButton)
 
         mMapButton = findViewById(R.id.map_button)
         mMapButton.setOnClickListener {
             onMapButtonClicked()
         }
-        expandViewHitArea(mExpandedSessionView, mMapButton)
 
         mGraphButton = findViewById(R.id.graph_button)
         mGraphButton.setOnClickListener {
             onGraphButtonClicked()
         }
-        expandViewHitArea(mExpandedSessionView, mGraphButton)
 
         mActionsButton.setOnClickListener {
             actionsButtonClicked()
@@ -220,6 +217,10 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
             mChartView?.visibility = View.VISIBLE
         }
         bindExpandedMeasurementsDesctription()
+
+        mSessionCardLayout.setPadding(mSessionCardLayout.paddingLeft, mSessionCardLayout.paddingTop, mSessionCardLayout.paddingRight, 0)
+
+        expandButtonsHitAreas(listOf(mGraphButton, mMapButton, mUnfollowButton, mFollowButton), mExpandedSessionView)
     }
 
     protected open fun collapseSessionCard() {
@@ -228,6 +229,8 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
 
         mMeasurementsTableContainer.makeStatic(showMeasurementsTableValues())
         bindCollapsedMeasurementsDesctription()
+
+        mSessionCardLayout.setPadding(mSessionCardLayout.paddingLeft, mSessionCardLayout.paddingTop, mSessionCardLayout.paddingRight, mSessionCardLayout.paddingRight)
     }
 
     protected fun setExpandCollapseButton() {
@@ -307,6 +310,7 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
     }
 
     private fun onExpandSessionCardClicked() {
+
         mSessionPresenter?.expanded = true
 
         mSessionPresenter?.session?.let {
@@ -314,24 +318,34 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
                 (listener as? SessionCardListener)?.onExpandSessionCard(it)
             }
         }
+
     }
 
     private fun onCollapseSessionCardClicked() {
         mSessionPresenter?.expanded = false
     }
 
-    private fun expandViewHitArea(container : View, child : View) {
-        val padding = 4
-        container.post {
-            val rect = Rect()
-            child.getHitRect(rect)
+    private fun getExpandedTouchDelegate(child: View) : TouchDelegate {
+        val paddingX = 10
+        val paddingY = 40
+        var rect = Rect()
+        child.getHitRect(rect)
+        rect.left -= paddingX
+        rect.top -= paddingY
+        rect.right += paddingX
+        rect.bottom += paddingY
 
-            rect.left -= padding
-            rect.top -= padding
-            rect.right += padding
-            rect.bottom += padding
+       return TouchDelegate(rect, child)
+    }
+    private fun expandButtonsHitAreas(buttons : List<View>, parentView : View) {
+        var touchDelegateComposite = TouchDelegateComposite(parentView)
 
-            container.touchDelegate = TouchDelegate(rect, child)
+        buttons.forEach { button ->
+            touchDelegateComposite.addDelegate(getExpandedTouchDelegate(button))
+        }
+
+        parentView.post {
+            parentView.touchDelegate = touchDelegateComposite
         }
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -310,7 +310,6 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
     }
 
     private fun onExpandSessionCardClicked() {
-
         mSessionPresenter?.expanded = true
 
         mSessionPresenter?.session?.let {
@@ -318,7 +317,6 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
                 (listener as? SessionCardListener)?.onExpandSessionCard(it)
             }
         }
-
     }
 
     private fun onCollapseSessionCardClicked() {
@@ -337,6 +335,7 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
 
        return TouchDelegate(rect, child)
     }
+
     private fun expandButtonsHitAreas(buttons : List<View>, parentView : View) {
         var touchDelegateComposite = TouchDelegateComposite(parentView)
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -4,6 +4,7 @@ import android.location.Location
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.fragment.app.FragmentManager
@@ -34,6 +35,7 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
     private val mMeasurementsTableContainer: MeasurementsTableContainer
     protected var mStatisticsContainer: StatisticsContainer?
     private val mMoreButton: ImageView?
+    private val mMoreInvisibleButton: Button?
     private val mHLUSlider: HLUSlider
 
     constructor(
@@ -47,7 +49,7 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
 
         mSessionDateTextView = this.rootView?.session_date
         mSessionNameTextView = this.rootView?.session_name
-        mSessionMeasurementsDescription = this.rootView?.session_measurements_description
+        mSessionMeasurementsDescription = this.findViewById(R.id.session_measurements_description)
 
         mMeasurementsTableContainer = MeasurementsTableContainer(
             context,
@@ -59,7 +61,11 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
 
         mStatisticsContainer = StatisticsContainer(this.rootView, context)
         mMoreButton = this.rootView?.more_button
+        mMoreInvisibleButton = this.rootView?.more_invisible_button
         mMoreButton?.setOnClickListener {
+            onMoreButtonPressed()
+        }
+        mMoreInvisibleButton?.setOnClickListener {
             onMoreButtonPressed()
         }
         mHLUSlider = HLUSlider(this.rootView, context, this::onSensorThresholdChanged)
@@ -91,7 +97,7 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
     }
 
     private fun showSlider() {
-        mMoreButton?.visibility = View.VISIBLE
+        mMoreButton?.visibility = context.resources.getInteger(R.integer.visible_in_larger_screens)
         mHLUSlider.show()
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -97,7 +97,15 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
     }
 
     private fun showSlider() {
-        if (context.resources.getInteger(R.integer.visible_in_larger_screens) != 0) {
+        val visibilityIndex = context.resources.getInteger(R.integer.visible_in_larger_screens)
+        /**
+        * 0 means visible, see VISIBILITY_FLAGS in View class:
+        * private static final int[] VISIBILITY_FLAGS = {VISIBLE, INVISIBLE, GONE};
+        * we keep them in integers.xml as indexes (0, 1, 2) instead of values (0, 4, 8)
+        * because this is how they are used in XML
+        */
+
+        if (visibilityIndex != 0) {
             mMoreButton?.visibility = View.GONE
         } else {
             mMoreButton?.visibility = View.VISIBLE

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -27,7 +27,6 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
 
     private val mSessionDateTextView: TextView?
     private val mSessionNameTextView: TextView?
-    private val mSessionTagsTextView: TextView?
     protected val mSessionMeasurementsDescription: TextView?
 
     protected var mSessionPresenter: SessionPresenter? = null
@@ -48,7 +47,6 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
 
         mSessionDateTextView = this.rootView?.session_date
         mSessionNameTextView = this.rootView?.session_name
-        mSessionTagsTextView = this.rootView?.session_info
         mSessionMeasurementsDescription = this.rootView?.session_measurements_description
 
         mMeasurementsTableContainer = MeasurementsTableContainer(
@@ -105,7 +103,6 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
 
         mSessionDateTextView?.text = session.durationString()
         mSessionNameTextView?.text = session.name
-        mSessionTagsTextView?.text = session.infoString()
         bindSessionMeasurementsDescription()
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -97,7 +97,11 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
     }
 
     private fun showSlider() {
-        mMoreButton?.visibility = context.resources.getInteger(R.integer.visible_in_larger_screens)
+        if (context.resources.getInteger(R.integer.visible_in_larger_screens) != 0) {
+            mMoreButton?.visibility = View.GONE
+        } else {
+            mMoreButton?.visibility = View.VISIBLE
+        }
         mHLUSlider.show()
     }
 

--- a/app/src/main/res/layout/activity_graph.xml
+++ b/app/src/main/res/layout/activity_graph.xml
@@ -17,6 +17,13 @@
     <include android:id="@+id/statistics_view"
         layout="@layout/session_details_statistics_view" />
 
+    <androidx.constraintlayout.widget.Guideline
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/guidelineStatistics"
+        app:layout_constraintGuide_percent="0.7"
+        android:orientation="vertical"/>
+
     <include layout="@layout/graph" />
 
     <include android:id="@+id/hlu" layout="@layout/hlu_slider"

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -16,6 +16,13 @@
 
     <include android:id="@+id/statistics_view" layout="@layout/session_details_statistics_view" />
 
+    <androidx.constraintlayout.widget.Guideline
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/guidelineStatistics"
+        app:layout_constraintGuide_percent="0.7"
+        android:orientation="vertical"/>
+
     <fragment
         android:id="@+id/map"
         android:name="com.google.android.libraries.maps.SupportMapFragment"

--- a/app/src/main/res/layout/expanded_session_view.xml
+++ b/app/src/main/res/layout/expanded_session_view.xml
@@ -3,7 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/keyline_4">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_sessions_tab.xml
+++ b/app/src/main/res/layout/fragment_sessions_tab.xml
@@ -24,8 +24,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="125dp"
-        android:layout_marginLeft="@dimen/keyline_12"
-        android:layout_marginRight="@dimen/keyline_12"
+        android:layout_marginLeft="@dimen/keyline_16"
+        android:layout_marginRight="@dimen/keyline_16"
         app:layout_constraintTop_toTopOf="parent" />
 
     <include
@@ -35,8 +35,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="125dp"
-        android:layout_marginLeft="@dimen/keyline_12"
-        android:layout_marginRight="@dimen/keyline_12"
+        android:layout_marginLeft="@dimen/keyline_16"
+        android:layout_marginRight="@dimen/keyline_16"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/did_you_know_box"/>
 

--- a/app/src/main/res/layout/hlu_slider.xml
+++ b/app/src/main/res/layout/hlu_slider.xml
@@ -21,7 +21,8 @@
         android:visibility="invisible"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/track"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        />
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/track"
@@ -127,6 +128,18 @@
         app:layout_constraintTop_toBottomOf="@id/track"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
+
+    <Button
+        android:id="@+id/more_invisible_button"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/labels"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:visibility="invisible"
+        android:clickable="true"
+        android:enabled="true"/>
 
     <com.google.android.material.slider.RangeSlider
         android:id="@+id/slider"

--- a/app/src/main/res/layout/hlu_slider.xml
+++ b/app/src/main/res/layout/hlu_slider.xml
@@ -137,7 +137,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/labels"
         app:layout_constraintBottom_toBottomOf="parent"
-        android:visibility="invisible"
+        android:background="@color/transparent"
         android:clickable="true"
         android:enabled="true"/>
 

--- a/app/src/main/res/layout/measurements_description.xml
+++ b/app/src/main/res/layout/measurements_description.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <TextView
+        android:id="@+id/session_measurements_description"
+        android:text="@string/session_measurements_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_10"
+        android:layout_marginEnd="@dimen/keyline_10"
+        android:layout_marginTop="@dimen/keyline_6"
+        android:textAppearance="?attr/textAppearanceBody2"
+        app:layout_constraintTop_toBottomOf="@+id/session_name"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:visibility="@integer/visible_in_larger_screens"/>
+</merge>

--- a/app/src/main/res/layout/measurements_table.xml
+++ b/app/src/main/res/layout/measurements_table.xml
@@ -10,7 +10,7 @@
         android:layout_marginEnd="@dimen/keyline_10"
         android:layout_marginTop="@dimen/keyline_6"
         android:textAppearance="?attr/textAppearanceBody2"
-        app:layout_constraintTop_toBottomOf="@+id/session_info"
+        app:layout_constraintTop_toBottomOf="@+id/session_name"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/measurements_table.xml
+++ b/app/src/main/res/layout/measurements_table.xml
@@ -1,18 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <TextView
-        android:id="@+id/session_measurements_description"
-        android:text="@string/session_measurements_description"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/keyline_10"
-        android:layout_marginEnd="@dimen/keyline_10"
-        android:layout_marginTop="@dimen/keyline_6"
-        android:textAppearance="?attr/textAppearanceBody2"
-        app:layout_constraintTop_toBottomOf="@+id/session_name"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+    <include layout="@layout/measurements_description" />
 
     <TableLayout
         android:id="@+id/measurements_table"

--- a/app/src/main/res/layout/session_card.xml
+++ b/app/src/main/res/layout/session_card.xml
@@ -13,7 +13,7 @@
         android:id="@+id/session_card_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:padding="@dimen/keyline_4" >
+        android:padding="@dimen/keyline_4">
 
         <TextView
             android:id="@+id/session_date"

--- a/app/src/main/res/layout/session_details.xml
+++ b/app/src/main/res/layout/session_details.xml
@@ -26,18 +26,4 @@
         app:layout_constraintTop_toBottomOf="@+id/session_date"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="parent" />
-
-    <TextView
-        android:id="@+id/session_info"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/keyline_10"
-        android:layout_marginEnd="@dimen/keyline_10"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:textAppearance="?attr/textAppearanceHeadline6"
-        android:textColor="@color/aircasting_dark_blue"
-        android:textSize="@dimen/text_size_xs"
-        app:layout_constraintTop_toBottomOf="@+id/session_name"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
 </merge>

--- a/app/src/main/res/layout/session_details.xml
+++ b/app/src/main/res/layout/session_details.xml
@@ -5,11 +5,12 @@
         android:id="@+id/session_date"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/keyline_10"
+        android:layout_marginStart="@dimen/keyline_17"
         android:layout_marginEnd="@dimen/keyline_10"
+        android:layout_marginTop="@dimen/keyline_8"
         android:textAppearance="?attr/textAppearanceBody2"
         android:textColor="@color/aircasting_grey_300"
-        app:layout_constraintTop_toBottomOf="@id/app_bar_layout"
+        app:layout_constraintTop_toTopOf="@id/app_bar_layout"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="parent" />
 
@@ -17,13 +18,13 @@
         android:id="@+id/session_name"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/keyline_10"
+        android:layout_marginStart="@dimen/keyline_17"
         android:layout_marginEnd="@dimen/keyline_10"
-        android:layout_marginTop="@dimen/keyline_4"
+        android:layout_marginTop="@dimen/keyline_3"
         android:textAppearance="?attr/textAppearanceHeadline2"
         android:textColor="@color/aircasting_dark_blue"
         android:fontFamily="@font/moderat_trial_medium"
         app:layout_constraintTop_toBottomOf="@+id/session_date"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/session_date"
         app:layout_constraintEnd_toStartOf="parent" />
 </merge>

--- a/app/src/main/res/layout/session_details_statistics_view.xml
+++ b/app/src/main/res/layout/session_details_statistics_view.xml
@@ -14,7 +14,10 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="@dimen/keyline_3">
+        android:paddingEnd="0dp"
+        android:paddingStart="0dp"
+        android:paddingTop="@dimen/keyline_2"
+        android:paddingBottom="@dimen/keyline_2">
 
         <TextView
             android:id="@+id/avg_label"

--- a/app/src/main/res/layout/session_details_statistics_view.xml
+++ b/app/src/main/res/layout/session_details_statistics_view.xml
@@ -2,33 +2,38 @@
 <com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="wrap_content"
+    android:layout_width="0dp"
     android:layout_height="wrap_content"
     style="@style/Widget.Aircasting.Cards"
     android:layout_marginTop="@dimen/keyline_6"
     android:layout_marginStart="@dimen/keyline_4"
+
     app:layout_constraintTop_toBottomOf="@id/measurements_table"
     app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="@id/guidelineStatistics"
     android:visibility="gone">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingEnd="0dp"
-        android:paddingStart="0dp"
         android:paddingTop="@dimen/keyline_2"
-        android:paddingBottom="@dimen/keyline_2">
+        android:paddingBottom="@dimen/keyline_2"
+
+>
 
         <TextView
             android:id="@+id/avg_label"
             android:text="@string/avg_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/keyline_9"
+
             style="@style/TextAppearance.Aircasting.MapStatisticsLabel"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@id/now_label"
-            android:layout_marginEnd="@dimen/keyline_8"/>
+            app:layout_constraintHorizontal_chainStyle="spread_inside"
+            />
 
         <TextView
             android:id="@+id/now_label"
@@ -38,20 +43,22 @@
             style="@style/TextAppearance.Aircasting.MapStatisticsLabel"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toEndOf="@id/avg_label"
-            app:layout_constraintEnd_toEndOf="@id/peak_label"
-            android:layout_marginStart="@dimen/keyline_8"
-            android:layout_marginEnd="@dimen/keyline_8" />
+            app:layout_constraintEnd_toStartOf="@id/peak_label"
+            app:layout_constraintHorizontal_chainStyle="spread_inside"
+     />
 
         <TextView
             android:id="@+id/peak_label"
             android:text="@string/peak_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/keyline_8"
             style="@style/TextAppearance.Aircasting.MapStatisticsLabel"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toEndOf="@id/now_label"
             app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginStart="@dimen/keyline_8"/>
+            app:layout_constraintHorizontal_chainStyle="spread_inside"
+          />
 
 
         <ImageView
@@ -72,8 +79,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/TextAppearance.Aircasting.MapStatisticsValue"
-            android:padding="@dimen/keyline_2"
+            android:padding="@dimen/keyline_1"
             android:paddingStart="@dimen/keyline_8"
+            android:paddingEnd="@dimen/keyline_3"
             app:layout_constraintTop_toBottomOf="@id/avg_label"
             app:layout_constraintStart_toStartOf="@id/avg_label"
             app:layout_constraintEnd_toEndOf="@id/avg_label"/>
@@ -96,8 +104,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/TextAppearance.Aircasting.MapStatisticsValue"
-            android:padding="@dimen/keyline_2"
+            android:padding="@dimen/keyline_1"
             android:paddingStart="@dimen/keyline_8"
+            android:paddingEnd="@dimen/keyline_3"
             android:textSize="@dimen/text_size_l"
             app:layout_constraintTop_toBottomOf="@id/now_label"
             app:layout_constraintStart_toStartOf="@+id/now_label"
@@ -121,8 +130,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/TextAppearance.Aircasting.MapStatisticsValue"
-            android:padding="@dimen/keyline_2"
+            android:padding="@dimen/keyline_1"
             android:paddingStart="@dimen/keyline_8"
+            android:paddingEnd="@dimen/keyline_3"
             app:layout_constraintTop_toBottomOf="@id/peak_label"
             app:layout_constraintStart_toStartOf="@id/peak_label"
             app:layout_constraintEnd_toEndOf="@id/peak_label"/>

--- a/app/src/main/res/values-h600dp/integers.xml
+++ b/app/src/main/res/values-h600dp/integers.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="view_visible">0</integer> <!--  VISIBLE -->
+    <integer name="view_invisible">1</integer> <!-- INVISIBLE -->
+    <integer name="view_gone">2</integer> <!-- GONE -->
+
+    <!-- session details -->
+    <integer name="visible_in_larger_screens">@integer/view_visible</integer>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -36,7 +36,8 @@
     <dimen name="keyline_7">28dp</dimen>
     <dimen name="keyline_8">32dp</dimen>
     <dimen name="keyline_10">40dp</dimen>
-    <dimen name="keyline_12">64dp</dimen>
+    <dimen name="keyline_16">64dp</dimen>
+    <dimen name="keyline_17">68dp</dimen>
 
     <dimen name="card_corner_radius">0dp</dimen>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -35,6 +35,7 @@
     <dimen name="keyline_6">24dp</dimen>
     <dimen name="keyline_7">28dp</dimen>
     <dimen name="keyline_8">32dp</dimen>
+    <dimen name="keyline_9">36dp</dimen>
     <dimen name="keyline_10">40dp</dimen>
     <dimen name="keyline_16">64dp</dimen>
     <dimen name="keyline_17">68dp</dimen>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="view_visible">0</integer> <!--  VISIBLE -->
+    <integer name="view_invisible">1</integer> <!-- INVISIBLE -->
+    <integer name="view_gone">2</integer> <!-- GONE -->
+
+    <!-- session details -->
+    <integer name="visible_in_larger_screens">@integer/view_gone</integer>
+</resources>


### PR DESCRIPTION
The [ticket](https://trello.com/c/FoUxrECt/971-map-graph-adjust-spacing-to-gain-vertical-display-space) was created because sessiin details looked very bad on smallest screens (example was Motorola with 720x1280 resolution). Micheal added few ideas, after consulting with Pina we decided to make a few changes (please review subtasks in the [ticket](https://trello.com/c/FoUxrECt/971-map-graph-adjust-spacing-to-gain-vertical-display-space) )

Additionally, I allowed myself to introduce qualifiers. For bigger screens (height > 600dp) I left the measurements description and the "more" button. For smaller screens they are hidden. I made hlu slider labels area clickable (it's like more button) so on smaller screens you can still get edit HLU thresholds. Both the min height (now 600 dp) and the elements can be changed, these are just my propositions. To be reviewed with Michael and/or Pina. 

Also, the statistics box (avg/now/peak) always takes the same percent of the with, so  on smaller screens it will be shrinked (smaller spaces between the values)

See screenshots for small vs big screen.

Small (< 600dp)
<img width="286" alt="Screenshot 2021-02-15 at 12 17 05" src="https://user-images.githubusercontent.com/443828/107942707-e818aa80-6f8b-11eb-9db3-8769ef4bafb5.png">

<img width="274" alt="Screenshot 2021-02-15 at 12 16 40" src="https://user-images.githubusercontent.com/443828/107942646-d46d4400-6f8b-11eb-9043-c268c01a1fc9.png">

Medium (> 600dp)

<img width="294" alt="Screenshot 2021-02-15 at 12 32 06" src="https://user-images.githubusercontent.com/443828/107942772-02528880-6f8c-11eb-92c5-62c34567ad85.png">
<img width="291" alt="Screenshot 2021-02-15 at 12 32 31" src="https://user-images.githubusercontent.com/443828/107942812-139b9500-6f8c-11eb-94d1-7c88e5d932b2.png">

Big (> 600dp)
![Screenshot_20210215-123411](https://user-images.githubusercontent.com/443828/107943240-b522e680-6f8c-11eb-80b9-56406e8df3bc.jpg)
![Screenshot_20210215-123429](https://user-images.githubusercontent.com/443828/107943249-b8b66d80-6f8c-11eb-95c5-1161b99d06e8.jpg)
