### PR TITLE
Checked if followed has changed - Session model

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/models/Session.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/models/Session.kt
@@ -240,6 +240,7 @@ class Session(
     fun hasChangedFrom(session: Session?): Boolean {
         return session?.name != name ||
                 session.tags != tags ||
+                session.followed != followed ||
                 session.streams.size != streams.size ||
                 session.measurementsCount() != measurementsCount() ||
                 session.status != status ||


### PR DESCRIPTION
Basically, it's a one-line fix: I've added one more condition (`session.followed != followed`) to `hasChangedFrom` function in the `Session` model. 

AC and how to test it:

Scenario 1:
-from the fixed tab, follow a session
-from the fixed tab, unfollow the same session
-from the fixed tab, follow the same session
-navigate to the following tab

- [ ] expected behavior: **The followed session should appear under the following tab.**

Scenario 2:
-from the fixed tab, follow a session
-from the following tab, unfollow the same session
-navigate back to the fixed tab

- [ ] expected behavior: **The button for this same session should be in the "follow" state.**

