### PR TITLE
small screen > mobile active > tip: create space between the button & tip

### DIFF
--- a/app/src/main/res/layout/fragment_sessions_tab.xml
+++ b/app/src/main/res/layout/fragment_sessions_tab.xml
@@ -34,9 +34,10 @@
         android:visibility="invisible"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="125dp"
+        android:layout_marginTop="@dimen/keyline_20"
         android:layout_marginLeft="@dimen/keyline_16"
         android:layout_marginRight="@dimen/keyline_16"
+        android:layout_marginBottom="@dimen/keyline_6"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/did_you_know_box"/>
 
@@ -49,6 +50,7 @@
         android:focusable="true"
         android:clickable="true"
         app:layout_constraintTop_toBottomOf="@id/empty_mobile_active_dashboard"
+        android:layout_marginTop="@dimen/keyline_6"
         android:layout_marginLeft="@dimen/keyline_6"
         android:layout_marginRight="@dimen/keyline_6"
         android:layout_marginBottom="@dimen/keyline_10"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -39,6 +39,7 @@
     <dimen name="keyline_10">40dp</dimen>
     <dimen name="keyline_16">64dp</dimen>
     <dimen name="keyline_17">68dp</dimen>
+    <dimen name="keyline_20">80dp</dimen>
 
     <dimen name="card_corner_radius">0dp</dimen>
 


### PR DESCRIPTION
https://trello.com/c/8clIPr0d/1145-small-screen-mobile-active-tip-create-space-between-the-button-tip

Now it looks like this on the smallest Test Lab screen:
![button-tip-space](https://user-images.githubusercontent.com/37418467/108852013-5ccf9280-75e5-11eb-801a-da156ad137da.png)
