### PR TITLE
Delete streams or session confirmation dialog

### DIFF
--- a/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
+++ b/app/src/androidTest/java/io/lunarlogic/aircasting/MobileSessionTest.kt
@@ -249,6 +249,6 @@ class MobileSessionTest {
         onView(withId(R.id.delete_streams_button)).perform(click())
         Thread.sleep(2000)
         // check if session deleted
-        onView(withText("Ania's mobile mic session")).check(matches(not(isDisplayed())))
+        onView(withText("Ania's mobile mic session")).check(doesNotExist())
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/ConfirmationDeleteSessionDialog.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/ConfirmationDeleteSessionDialog.kt
@@ -1,0 +1,30 @@
+package io.lunarlogic.aircasting.screens.dashboard
+
+import android.view.LayoutInflater
+import android.view.View
+import androidx.fragment.app.FragmentManager
+import io.lunarlogic.aircasting.R
+import io.lunarlogic.aircasting.screens.common.BaseDialog
+import kotlinx.android.synthetic.main.network_password_dialog.view.*
+import kotlinx.android.synthetic.main.session_actions.view.cancel_button
+
+class ConfirmationDeleteSessionDialog(
+    private val mFragmentManager: FragmentManager,
+    val function: () -> (Unit)
+): BaseDialog(mFragmentManager) {
+    private lateinit var mView: View
+    override fun setupView(inflater: LayoutInflater): View {
+        mView = inflater.inflate(R.layout.confirmation_dialog, null)
+        mView.ok_button.setOnClickListener {
+            okButtonClicked()
+        }
+        mView.cancel_button.setOnClickListener {
+            dismiss()
+        }
+        return mView
+    }
+    private fun okButtonClicked() {
+        function()
+        dismiss()
+    }
+}

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/ConfirmationDeleteSessionDialog.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/ConfirmationDeleteSessionDialog.kt
@@ -10,7 +10,7 @@ import kotlinx.android.synthetic.main.session_actions.view.cancel_button
 
 class ConfirmationDeleteSessionDialog(
     private val mFragmentManager: FragmentManager,
-    val function: () -> (Unit)
+    val okCallback: () -> (Unit)
 ): BaseDialog(mFragmentManager) {
     private lateinit var mView: View
     override fun setupView(inflater: LayoutInflater): View {
@@ -24,7 +24,7 @@ class ConfirmationDeleteSessionDialog(
         return mView
     }
     private fun okButtonClicked() {
-        function()
+        okCallback()
         dismiss()
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
@@ -1,7 +1,11 @@
 package io.lunarlogic.aircasting.screens.dashboard
 
+import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
+import android.view.View
+import android.widget.Button
+import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
@@ -177,9 +181,33 @@ abstract class SessionsController(
         val allStreamsBoxSelected: Boolean = (deleteSessionDialog?.allStreamsBoxSelected() == true)
         val streamsToDelete = deleteSessionDialog?.getStreamsToDelete()
         if (deleteAllStreamsSelected(allStreamsBoxSelected, streamsToDelete?.size, session.streams.size )) {
-            deleteSession(session.uuid)
+            showConfirmationDialog { deleteSession(session.uuid) }
         } else  {
-            deleteStreams(session, streamsToDelete)
+            showConfirmationDialog { deleteStreams(session, streamsToDelete) }
+        }
+    }
+
+    private fun showConfirmationDialog(function: () -> (Unit)) {
+        val builder = AlertDialog.Builder(this.context)
+        val inflater = this.mRootActivity?.layoutInflater!!
+        val dialogView: View = inflater.inflate(R.layout.confirmation_dialog, null)
+        builder.setView(dialogView)
+
+        val okButton: Button = dialogView.findViewById(R.id.ok_button) as Button
+        val cancelButton: Button = dialogView.findViewById(R.id.cancel_button) as Button
+        val header: TextView = dialogView.findViewById(R.id.confirmation_dialog_header)
+        header.text = this.context?.getString(R.string.are_you_sure)
+        val dialog: AlertDialog = builder.create()
+        dialog.show()
+
+        okButton.setOnClickListener {
+            function()
+            dialog.dismiss()
+        }
+
+        cancelButton.setOnClickListener {
+            // Do nothing but close the dialog
+            dialog.cancel()
         }
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
@@ -181,31 +181,13 @@ abstract class SessionsController(
         val allStreamsBoxSelected: Boolean = (deleteSessionDialog?.allStreamsBoxSelected() == true)
         val streamsToDelete = deleteSessionDialog?.getStreamsToDelete()
         if (deleteAllStreamsSelected(allStreamsBoxSelected, streamsToDelete?.size, session.streams.size )) {
-            showConfirmationDialog { deleteSession(session.uuid) }
+            ConfirmationDeleteSessionDialog(this.fragmentManager) {
+                deleteSession(session.uuid) }
+                .show()
         } else  {
-            showConfirmationDialog { deleteStreams(session, streamsToDelete) }
-        }
-    }
-
-    private fun showConfirmationDialog(function: () -> (Unit)) {
-        val builder = AlertDialog.Builder(this.context)
-        val inflater = this.mRootActivity?.layoutInflater!!
-        val dialogView: View = inflater.inflate(R.layout.confirmation_dialog, null)
-        builder.setView(dialogView)
-
-        val okButton: Button = dialogView.findViewById(R.id.ok_button) as Button
-        val cancelButton: Button = dialogView.findViewById(R.id.cancel_button) as Button
-        val dialog: AlertDialog = builder.create()
-        dialog.show()
-
-        okButton.setOnClickListener {
-            function()
-            dialog.dismiss()
-        }
-
-        cancelButton.setOnClickListener {
-            // Do nothing but close the dialog
-            dialog.cancel()
+            ConfirmationDeleteSessionDialog(this.fragmentManager) {
+                deleteStreams(session, streamsToDelete) }
+                .show()
         }
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
@@ -195,8 +195,6 @@ abstract class SessionsController(
 
         val okButton: Button = dialogView.findViewById(R.id.ok_button) as Button
         val cancelButton: Button = dialogView.findViewById(R.id.cancel_button) as Button
-        val header: TextView = dialogView.findViewById(R.id.confirmation_dialog_header)
-        header.text = this.context?.getString(R.string.are_you_sure)
         val dialog: AlertDialog = builder.create()
         dialog.show()
 

--- a/app/src/main/res/layout/confirmation_dialog.xml
+++ b/app/src/main/res/layout/confirmation_dialog.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.LinearLayoutCompat
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/dialog_background">
+
+    <TextView
+        android:id="@+id/confirmation_dialog_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        style="@style/TextAppearance.Aircasting.NewSessionDetails.Headline1"
+        android:textSize="@dimen/text_size_m"
+        app:lineHeight="@dimen/keyline_6"
+        android:layout_marginTop="@dimen/keyline_8"
+        android:layout_marginStart="@dimen/keyline_8"
+        android:layout_marginEnd="@dimen/keyline_8"
+        android:layout_marginBottom="@dimen/keyline_6" />
+
+    <Button
+        android:id="@+id/ok_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_6"
+        android:layout_marginStart="@dimen/keyline_8"
+        android:layout_marginEnd="@dimen/keyline_8"
+        android:text="@string/ok" />
+
+    <Button
+        android:id="@+id/cancel_button"
+        style="@style/Widget.Aircasting.TextButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/moderat_trial_bold"
+        android:textSize="@dimen/button_text_size"
+        android:text="@string/cancel"
+        android:layout_marginStart="@dimen/keyline_8"
+        android:layout_marginEnd="@dimen/keyline_8"
+        android:layout_marginBottom="@dimen/keyline_6" />
+
+</androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/confirmation_dialog.xml
+++ b/app/src/main/res/layout/confirmation_dialog.xml
@@ -14,6 +14,7 @@
         style="@style/TextAppearance.Aircasting.NewSessionDetails.Headline1"
         android:textSize="@dimen/text_size_m"
         app:lineHeight="@dimen/keyline_6"
+        android:text="@string/are_you_sure"
         android:layout_marginTop="@dimen/keyline_8"
         android:layout_marginStart="@dimen/keyline_8"
         android:layout_marginEnd="@dimen/keyline_8"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="delete_streams">Delete streams</string>
     <string name="delete_all_data_from_session">All from this session</string>
     <string name="delete_streams_subtitle">Which streams would you like to delete?</string>
+    <string name="are_you_sure">Are you sure?</string>
 
     <string name="disconnected_view_airbeam3_header">Your AirBeam3 is now\nin stand-alone mode</string>
     <string name="disconnected_view_airbeam3_description">AirBeam3 is now recording using its SD card. The measurements will be displayed here after syncing.</string>


### PR DESCRIPTION
**Important changes**:
-I've added a custom alert dialog layout
-I've added an alert dialog before deleting streams or sessions

AC:
- [x] On click `delete streams` confirmation dialog should appear
- [x] On click `ok` button should delete streams or session
- [x] On click `cancel` should come back to delete session dialog

<img width="318" alt="Screenshot 2021-02-23 at 16 28 14" src="https://user-images.githubusercontent.com/23139274/108868230-4b42b680-75f6-11eb-9fa0-c35a07bb372b.png">
 [ticket](https://trello.com/c/M0xQzlU9/1138-add-confirmation-dialog-before-deleting-a-session)