### PR TITLE
mobile active > graph: by default, show most recent half hour

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
@@ -86,7 +86,7 @@ class GraphContainer: OnChartGestureListener {
         drawData(entries)
         drawMidnightPointLines(result.midnightPoints)
         drawThresholds()
-//        setLabels() todo: this line sets bad labels on graph, without it is ok
+        setLabels()
 
         mGraph?.invalidate()
         mGraph?.calculateOffsets()
@@ -121,6 +121,7 @@ class GraphContainer: OnChartGestureListener {
         val centerY = (last.y - first.y) / 2
 
         mGraph.zoom(zoom, 1f, centerX, centerY)
+        mGraph.moveViewToX(last.x - Math.min(zoomSpan, span))
 
         val from = Math.max(last.x - zoomSpan, first.x)
         val to = last.x

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
@@ -86,7 +86,7 @@ class GraphContainer: OnChartGestureListener {
         drawData(entries)
         drawMidnightPointLines(result.midnightPoints)
         drawThresholds()
-        setLabels()
+//        setLabels() todo: this line sets bad labels on graph, without it is ok
 
         mGraph?.invalidate()
         mGraph?.calculateOffsets()

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphViewMobileActiveMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphViewMobileActiveMvcImpl.kt
@@ -16,6 +16,6 @@ class GraphViewMobileActiveMvcImpl(
     }
 
     override fun defaultZoomSpan(): Int? {
-        return 30 * 60 * 1000 // 30 minutes
+        return 2 * 60 * 1000 // 30 minutes, changed to 2 minutes
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphViewMobileActiveMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphViewMobileActiveMvcImpl.kt
@@ -16,6 +16,6 @@ class GraphViewMobileActiveMvcImpl(
     }
 
     override fun defaultZoomSpan(): Int? {
-        return 2 * 60 * 1000 // 30 minutes, changed to 2 minutes
+        return 30 * 60 * 1000 // 30 minutes
     }
 }


### PR DESCRIPTION
https://trello.com/c/nbuYAxgL/1150-mobile-active-graph-by-default-show-most-recent-half-hour