### PR TITLE
Remove old measurements

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
@@ -49,4 +49,8 @@ interface MeasurementDao {
 
     @Query("DELETE FROM measurements")
     fun deleteAll()
+
+    @Query("SELECT * FROM measurements WHERE session_id in (:sessionsIds)")
+    fun getBySessionsIds(sessionsIds: List<Long>): List<MeasurementDBObject>
+
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
@@ -53,6 +53,11 @@ interface MeasurementDao {
     @Query("SELECT * FROM measurements WHERE session_id in (:sessionsIds)")
     fun getBySessionsIds(sessionsIds: List<Long>): List<MeasurementDBObject>
 
-    @Query("DELETE FROM measurements WHERE id=:id")
-    fun delete(id: Long)
+    @Query("DELETE FROM measurements WHERE id in (:ids)")
+    fun delete(ids: List<Long>)
+
+    @Transaction
+    fun deleteInTransaction(ids: List<Long>) {
+        delete(ids)
+    }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
@@ -50,14 +50,11 @@ interface MeasurementDao {
     @Query("DELETE FROM measurements")
     fun deleteAll()
 
-    @Query("SELECT * FROM measurements WHERE session_id in (:sessionsIds)")
-    fun getBySessionsIds(sessionsIds: List<Long>): List<MeasurementDBObject>
-
-    @Query("DELETE FROM measurements WHERE id in (:ids)")
-    fun delete(ids: List<Long>)
+    @Query("DELETE FROM measurements WHERE time <= datetime('now', '-1 day') AND session_id in (:sessionIds)")
+    fun delete(sessionIds: List<Long>)
 
     @Transaction
-    fun deleteInTransaction(ids: List<Long>) {
-        delete(ids)
+    fun deleteInTransaction(sessionIds: List<Long>) {
+        delete(sessionIds)
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
@@ -53,4 +53,6 @@ interface MeasurementDao {
     @Query("SELECT * FROM measurements WHERE session_id in (:sessionsIds)")
     fun getBySessionsIds(sessionsIds: List<Long>): List<MeasurementDBObject>
 
+    @Query("DELETE FROM measurements WHERE id=:id")
+    fun delete(id: Long)
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/sessions.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/sessions.kt
@@ -170,4 +170,7 @@ interface SessionDao {
 
     @Query("DELETE FROM sessions WHERE uuid in (:uuids)")
     fun delete(uuids: List<String>)
+
+    @Query("SELECT id FROM sessions WHERE type=:type AND deleted=0")
+    fun loadSessionUuidsByType(type: Session.Type): List<Long>
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
@@ -45,4 +45,9 @@ class MeasurementsRepository {
         val measurement = mDatabase.measurements().lastForStream(sessionId, measurementStreamId)
         return measurement?.time
     }
+
+    fun getMeasurementsBySessionsIds(sessionsIds: List<Long>): List<MeasurementDBObject> {
+        return mDatabase.measurements().getBySessionsIds(sessionsIds)
+    }
+
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
@@ -46,13 +46,9 @@ class MeasurementsRepository {
         return measurement?.time
     }
 
-    fun getMeasurementsBySessionsIds(sessionsIds: List<Long>): List<MeasurementDBObject> {
-        return mDatabase.measurements().getBySessionsIds(sessionsIds)
-    }
-
-    fun deleteMeasurements(measurementsIds: List<Long>) {
+    fun deleteMeasurements(sessionIds: List<Long>) {
         mDatabase.runInTransaction {
-            mDatabase.measurements().deleteInTransaction(measurementsIds)
+            mDatabase.measurements().deleteInTransaction(sessionIds)
         }
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
@@ -50,4 +50,8 @@ class MeasurementsRepository {
         return mDatabase.measurements().getBySessionsIds(sessionsIds)
     }
 
+    fun deleteMeasurements(measurementsIds: List<Long>) {
+        measurementsIds.forEach { measurementId -> mDatabase.measurements().delete(measurementId) }
+    }
+
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
@@ -51,7 +51,9 @@ class MeasurementsRepository {
     }
 
     fun deleteMeasurements(measurementsIds: List<Long>) {
-        measurementsIds.forEach { measurementId -> mDatabase.measurements().delete(measurementId) }
+        mDatabase.runInTransaction {
+            mDatabase.measurements().deleteInTransaction(measurementsIds)
+        }
     }
 
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/SessionsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/SessionsRepository.kt
@@ -80,6 +80,10 @@ class SessionsRepository {
         return mDatabase.sessions().byType(Session.Type.FIXED)
     }
 
+    fun sessionsIdsByType(type: Session.Type): List<Long> {
+        return mDatabase.sessions().loadSessionUuidsByType(type)
+    }
+
     fun delete(uuids: List<String>) {
         if (!uuids.isEmpty()) {
             mDatabase.sessions().delete(uuids)

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
@@ -1,41 +1,11 @@
 package io.lunarlogic.aircasting.networking.services
 
-import io.lunarlogic.aircasting.database.data_classes.MeasurementDBObject
 import io.lunarlogic.aircasting.database.repositories.MeasurementsRepository
 
 class RemoveOldMeasurementsService() {
-    private val TWENTY_FOUR_HOURS_IN_MILLISECONDS = 24  *  60  *  60  *  1000
     private val measurementRepository = MeasurementsRepository()
 
     fun removeMeasurementsFromSessions(fixedSessionsIds: List<Long>) {
-        val fixedSessionsMeasurements = getFixedSessionsMeasurements(fixedSessionsIds)
-        val measurementsForDeletionIds = findMeasurementsForDeletion(fixedSessionsMeasurements)
-        if (measurementsForDeletionIds.isNotEmpty()) {
-            measurementRepository.deleteMeasurements(measurementsForDeletionIds)
-        }
-    }
-
-    private fun getFixedSessionsMeasurements(fixedSessionsIds: List<Long>): List<MeasurementDBObject> {
-        return measurementRepository.getMeasurementsBySessionsIds(fixedSessionsIds)
-    }
-
-    private fun findMeasurementsForDeletion(fixedSessionsMeasurements: List<MeasurementDBObject>): List<Long> {
-        val measurementsIdsForDeletion: MutableList<Long> = mutableListOf()
-        fixedSessionsMeasurements.forEach { measurement ->
-            // `measurement.time.time` looks weird, but it's just getTime() current syntax
-            // it returns the number of milliseconds since January 1, 1970, 00:00:00 GMT represented by this Date object.
-            // Source: https://developer.android.com/reference/kotlin/java/util/Date
-            val measurementTimeInMilliseconds = measurement.time.time
-            if (measurementOlderThanTwentyFourHours(measurementTimeInMilliseconds)) {
-                measurementsIdsForDeletion.add(measurement.id)
-            }
-        }
-        return measurementsIdsForDeletion
-    }
-
-    private fun measurementOlderThanTwentyFourHours(measurementTimeInMilliseconds: Long): Boolean {
-        val currentTimeInMilliseconds = System.currentTimeMillis()
-        val timeDifference = currentTimeInMilliseconds.minus(measurementTimeInMilliseconds)
-        return timeDifference >= TWENTY_FOUR_HOURS_IN_MILLISECONDS
+        measurementRepository.deleteMeasurements(fixedSessionsIds)
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
@@ -21,7 +21,7 @@ class RemoveOldMeasurementsService() {
 
     private fun findMeasurementsForDeletion(fixedSessionsMeasurements: List<MeasurementDBObject>): List<Long> {
         val measurementsIdsForDeletion: MutableList<Long> = mutableListOf()
-        fixedSessionsMeasurements.map { measurement ->
+        fixedSessionsMeasurements.forEach { measurement ->
             // `measurement.time.time` looks weird, but it's just getTime() current syntax
             // it returns the number of milliseconds since January 1, 1970, 00:00:00 GMT represented by this Date object.
             // Source: https://developer.android.com/reference/kotlin/java/util/Date

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
@@ -1,0 +1,41 @@
+package io.lunarlogic.aircasting.networking.services
+
+import io.lunarlogic.aircasting.database.data_classes.MeasurementDBObject
+import io.lunarlogic.aircasting.database.repositories.MeasurementsRepository
+
+class RemoveOldMeasurementsService() {
+    private val TWENTY_FOUR_HOURS_IN_MILLISECONDS = 24  *  60  *  60  *  1000
+    private val measurementRepository = MeasurementsRepository()
+
+    fun removeMeasurementsFromSessions(fixedSessionsIds: List<Long>) {
+        val fixedSessionsMeasurements = getFixedSessionsMeasurements(fixedSessionsIds)
+        val measurementsForDeletionIds = findMeasurementsForDeletion(fixedSessionsMeasurements)
+        if (measurementsForDeletionIds.isNotEmpty()) {
+            measurementRepository.deleteMeasurements(measurementsForDeletionIds)
+        }
+    }
+
+    private fun getFixedSessionsMeasurements(fixedSessionsIds: List<Long>): List<MeasurementDBObject> {
+        return measurementRepository.getMeasurementsBySessionsIds(fixedSessionsIds)
+    }
+
+    private fun findMeasurementsForDeletion(fixedSessionsMeasurements: List<MeasurementDBObject>): List<Long> {
+        val measurementsIdsForDeletion: MutableList<Long> = mutableListOf()
+        fixedSessionsMeasurements.map { measurement ->
+            // `measurement.time.time` looks weird, but it's just getTime() current syntax
+            // it returns the number of milliseconds since January 1, 1970, 00:00:00 GMT represented by this Date object.
+            // Source: https://developer.android.com/reference/kotlin/java/util/Date
+            val measurementTimeInMilliseconds = measurement.time.time
+            if (measurementOlderThanTwentyFourHours(measurementTimeInMilliseconds)) {
+                measurementsIdsForDeletion.add(measurement.id)
+            }
+        }
+        return measurementsIdsForDeletion
+    }
+
+    private fun measurementOlderThanTwentyFourHours(measurementTimeInMilliseconds: Long): Boolean {
+        val currentTimeInMilliseconds = System.currentTimeMillis()
+        val timeDifference = currentTimeInMilliseconds.minus(measurementTimeInMilliseconds)
+        return timeDifference >= TWENTY_FOUR_HOURS_IN_MILLISECONDS
+    }
+}

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
@@ -1,11 +1,15 @@
 package io.lunarlogic.aircasting.networking.services
 
 import io.lunarlogic.aircasting.database.repositories.MeasurementsRepository
+import io.lunarlogic.aircasting.database.repositories.SessionsRepository
+import io.lunarlogic.aircasting.models.Session
 
 class RemoveOldMeasurementsService() {
     private val measurementRepository = MeasurementsRepository()
+    private val sessionRepository = SessionsRepository()
 
-    fun removeMeasurementsFromSessions(fixedSessionsIds: List<Long>) {
+    fun removeMeasurementsFromSessions() {
+        val fixedSessionsIds = sessionRepository.sessionsIdsByType(Session.Type.FIXED)
         measurementRepository.deleteMeasurements(fixedSessionsIds)
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/SessionsSyncService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/SessionsSyncService.kt
@@ -25,6 +25,7 @@ class SessionsSyncService {
 
     private val uploadService: MobileSessionUploadService
     private val downloadService: SessionDownloadService
+    private val removeOldMeasurementsService: RemoveOldMeasurementsService
 
     private val sessionRepository = SessionsRepository()
     private val measurementStreamsRepository = MeasurementStreamsRepository()
@@ -42,6 +43,7 @@ class SessionsSyncService {
 
         this.uploadService = MobileSessionUploadService(apiService, errorHandler)
         this.downloadService = SessionDownloadService(apiService, errorHandler)
+        this.removeOldMeasurementsService = RemoveOldMeasurementsService()
     }
 
     companion object {
@@ -105,6 +107,7 @@ class SessionsSyncService {
                                 delete(body.deleted)
                                 upload(body.upload)
                                 download(body.download)
+                                removeOldMeasurements()
 
                                 onSuccessCallback?.invoke()
                             }
@@ -123,6 +126,11 @@ class SessionsSyncService {
                 }
             })
         }
+    }
+
+    private fun removeOldMeasurements() {
+        val fixedSessionsIds = sessionRepository.sessionsIdsByType(Session.Type.FIXED)
+        removeOldMeasurementsService.removeMeasurementsFromSessions(fixedSessionsIds)
     }
 
     private fun deleteMarkedForRemoval() {

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/SessionsSyncService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/SessionsSyncService.kt
@@ -129,8 +129,7 @@ class SessionsSyncService {
     }
 
     private fun removeOldMeasurements() {
-        val fixedSessionsIds = sessionRepository.sessionsIdsByType(Session.Type.FIXED)
-        removeOldMeasurementsService.removeMeasurementsFromSessions(fixedSessionsIds)
+        removeOldMeasurementsService.removeMeasurementsFromSessions()
     }
 
     private fun deleteMarkedForRemoval() {


### PR DESCRIPTION
Important changes:

- I've added `removeOldMeasurements()` function during sync session
- I've created `RemoveOldMeasurementsService` in order to find all fixed sessions measurements older than 24 hours 
- I've added getting sessions ids by their type both in data class and repository
- I've added getting measurements by session ids both in data class and repository
- I've added deleting measurements by their id both in data class and repository