### PR TITLE
When there are no measurement values in the measurements table, headers should be aligned to the left.

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -121,8 +121,8 @@ class MeasurementsTableContainer {
     }
 
     private fun stretchTableLayout() {
-        val session = mSessionPresenter?.session
-        if (mSessionPresenter?.expanded == true && session?.activeStreams?.size !!> 1) {
+        val session = mSessionPresenter?.session ?: return
+        if (mSessionPresenter?.expanded == true && session.activeStreams.size > 1) {
             mMeasurementsTable?.isStretchAllColumns = true
         }
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -122,7 +122,7 @@ class MeasurementsTableContainer {
 
     private fun stretchTableLayout() {
         val session = mSessionPresenter?.session
-        if (session != null && session.activeStreams.size > 1) {
+        if (mSessionPresenter?.expanded == true && session?.activeStreams?.size !!> 1) {
             mMeasurementsTable?.isStretchAllColumns = true
         }
     }

--- a/app/src/main/res/layout/measurement_header.xml
+++ b/app/src/main/res/layout/measurement_header.xml
@@ -2,7 +2,8 @@
     android:orientation="horizontal"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:clickable="true">
+    android:clickable="true"
+    android:paddingEnd="@dimen/keyline_3">
 
     <TextView
         android:id="@+id/measurement_header"

--- a/app/src/main/res/layout/session_card.xml
+++ b/app/src/main/res/layout/session_card.xml
@@ -113,9 +113,7 @@
             android:layout_marginTop="@dimen/keyline_2"
             app:layout_constraintTop_toBottomOf="@+id/session_measurements_description">
 
-            <TableRow android:id="@+id/measurement_headers"
-                android:layout_gravity="start"
-                android:layout_width="wrap_content"/>
+            <TableRow android:id="@+id/measurement_headers"/>
             <TableRow android:id="@+id/measurement_values" />
         </TableLayout>
 

--- a/app/src/main/res/layout/session_card.xml
+++ b/app/src/main/res/layout/session_card.xml
@@ -113,7 +113,9 @@
             android:layout_marginTop="@dimen/keyline_2"
             app:layout_constraintTop_toBottomOf="@+id/session_measurements_description">
 
-            <TableRow android:id="@+id/measurement_headers" />
+            <TableRow android:id="@+id/measurement_headers"
+                android:layout_gravity="start"
+                android:layout_width="wrap_content"/>
             <TableRow android:id="@+id/measurement_values" />
         </TableLayout>
 


### PR DESCRIPTION
https://trello.com/c/o8Pclx4g/1141-when-there-are-no-measurement-values-in-the-measurements-table-headers-should-be-aligned-to-the-left