### PR TITLE
roll back changes to parameter spacing

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -121,8 +121,8 @@ class MeasurementsTableContainer {
     }
 
     private fun stretchTableLayout() {
-        val session = mSessionPresenter?.session ?: return
-        if (mSessionPresenter?.expanded == true && session.activeStreams.size > 1) {
+        val session = mSessionPresenter?.session
+        if (session != null && session.activeStreams.size > 1) {
             mMeasurementsTable?.isStretchAllColumns = true
         }
     }

--- a/app/src/main/res/layout/measurement_header.xml
+++ b/app/src/main/res/layout/measurement_header.xml
@@ -2,8 +2,7 @@
     android:orientation="horizontal"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:clickable="true"
-    android:paddingEnd="@dimen/keyline_3">
+    android:clickable="true">
 
     <TextView
         android:id="@+id/measurement_header"


### PR DESCRIPTION
https://trello.com/c/o8Pclx4g/1141-when-there-are-no-measurement-values-in-the-measurements-table-headers-should-be-aligned-to-the-left