### PR TITLE
Fix progress bar to show correct progress

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/lib/ProgressBarCounter.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/lib/ProgressBarCounter.kt
@@ -12,14 +12,9 @@ class ProgressBarCounter(
         currentProgressMax += STEP_PROGRESS * stepsNumber
     }
 
-    fun decreaseMaxProgress(stepsNumber: Int) {
-        //todo: maybe needed when going back after selecting device type == bluetooth device
-        currentProgressMax -= STEP_PROGRESS * stepsNumber
-    }
-
     companion object {
         val DEFAULT_STEP_NUMBER = 4  // we got 3 basic steps in the flow (progress bar should have 1 more to look better)
-        val DEFAULT_ONBOARDING_STEP_NUMBER = 7
+        val DEFAULT_ONBOARDING_STEP_NUMBER = 6
         val DEFAULT_MAX_PROGRESS_INCREASE = 1
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/lib/ProgressBarCounter.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/lib/ProgressBarCounter.kt
@@ -3,9 +3,6 @@ package io.lunarlogic.aircasting.lib
 class ProgressBarCounter(
   var initialStepNumber: Int = DEFAULT_STEP_NUMBER
 ) {
-    private val STEP_PROGRESS = 10
-
-
     var currentProgressMax = STEP_PROGRESS * initialStepNumber
 
     fun increaseMaxProgress(stepsNumber: Int = DEFAULT_MAX_PROGRESS_INCREASE) {
@@ -16,5 +13,6 @@ class ProgressBarCounter(
         val DEFAULT_STEP_NUMBER = 4  // we got 3 basic steps in the flow (progress bar should have 1 more to look better)
         val DEFAULT_ONBOARDING_STEP_NUMBER = 6
         val DEFAULT_MAX_PROGRESS_INCREASE = 1
+        private val STEP_PROGRESS = 10
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/lib/ProgressBarCounter.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/lib/ProgressBarCounter.kt
@@ -15,12 +15,4 @@ class ProgressBarCounter(
         //todo: maybe needed when going back after selecting device type == bluetooth device
         currentProgressMax -= STEP_PROGRESS * stepsNumber
     }
-
-    companion object {
-        val DEFAULT_INITIAL_STEP_NUMBER_NEW_SESSION_FLOW = 4
-        val ADDITIONAL_STEPS_LOCATION_OFF = 1
-        val ADDITIONAL_STEPS_BLUETOOTH_OFF = 1
-        val ADDITIONAL_STEPS_DISABLED_MAPS = 1
-        val ADDITIONAL_STEPS_BLUETOOTH_DEVICE = 4
-    }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/lib/ProgressBarCounter.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/lib/ProgressBarCounter.kt
@@ -1,18 +1,25 @@
 package io.lunarlogic.aircasting.lib
 
 class ProgressBarCounter(
-  var initialStepNumber: Int
+  var initialStepNumber: Int = DEFAULT_STEP_NUMBER
 ) {
     private val STEP_PROGRESS = 10
 
+
     var currentProgressMax = STEP_PROGRESS * initialStepNumber
 
-    fun increaseMaxProgress(stepsNumber: Int) {
+    fun increaseMaxProgress(stepsNumber: Int = DEFAULT_MAX_PROGRESS_INCREASE) {
         currentProgressMax += STEP_PROGRESS * stepsNumber
     }
 
     fun decreaseMaxProgress(stepsNumber: Int) {
         //todo: maybe needed when going back after selecting device type == bluetooth device
         currentProgressMax -= STEP_PROGRESS * stepsNumber
+    }
+
+    companion object {
+        val DEFAULT_STEP_NUMBER = 4  // we got 3 basic steps in the flow (progress bar should have 1 more to look better)
+        val DEFAULT_ONBOARDING_STEP_NUMBER = 7
+        val DEFAULT_MAX_PROGRESS_INCREASE = 1
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/lib/ProgressBarCounter.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/lib/ProgressBarCounter.kt
@@ -1,0 +1,26 @@
+package io.lunarlogic.aircasting.lib
+
+class ProgressBarCounter(
+  var initialStepNumber: Int
+) {
+    private val STEP_PROGRESS = 10
+
+    var currentProgressMax = STEP_PROGRESS * initialStepNumber
+
+    fun increaseMaxProgress(stepsNumber: Int) {
+        currentProgressMax += STEP_PROGRESS * stepsNumber
+    }
+
+    fun decreaseMaxProgress(stepsNumber: Int) {
+        //todo: maybe needed when going back after selecting device type == bluetooth device
+        currentProgressMax -= STEP_PROGRESS * stepsNumber
+    }
+
+    companion object {
+        val DEFAULT_INITIAL_STEP_NUMBER_NEW_SESSION_FLOW = 4
+        val ADDITIONAL_STEPS_LOCATION_OFF = 1
+        val ADDITIONAL_STEPS_BLUETOOTH_OFF = 1
+        val ADDITIONAL_STEPS_DISABLED_MAPS = 1
+        val ADDITIONAL_STEPS_BLUETOOTH_DEVICE = 4
+    }
+}

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/common/BaseWizardNavigator.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/common/BaseWizardNavigator.kt
@@ -16,7 +16,7 @@ abstract class BaseWizardNavigator(
     }
 
     protected abstract val STEP_PROGRESS: Int
-    val progressBarCounter = ProgressBarCounter(4) // we got 3 basic steps in the flow (progress bar should have 1 more to look better)
+    val progressBarCounter = ProgressBarCounter()
     private var currentProgressStep = 0
     private var backPressedListener: BackPressedListener? = null
 
@@ -47,6 +47,18 @@ abstract class BaseWizardNavigator(
         val progressBar = mViewMvc.rootView?.findViewById<ProgressBar>(R.id.progress_bar)
         progressBar?.progress = currentProgressStep * STEP_PROGRESS
         progressBar?.max = progressBarCounter.currentProgressMax
+    }
+
+    open fun setupProgressBarMax(locationServicesAreOff: Boolean, areMapsDisabled: Boolean, isBluetoothDisabled: Boolean) {
+        if (locationServicesAreOff) {
+            progressBarCounter.increaseMaxProgress() // 1 additional step in flow
+        }
+        if (areMapsDisabled) {
+            progressBarCounter.increaseMaxProgress() // 1 additional step in flow
+        }
+        if (isBluetoothDisabled) {
+            progressBarCounter.increaseMaxProgress() // 1 additional step in flow
+        }
     }
 
     protected fun goToFragment(fragment: Fragment) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/common/BaseWizardNavigator.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/common/BaseWizardNavigator.kt
@@ -16,7 +16,7 @@ abstract class BaseWizardNavigator(
     }
 
     protected abstract val STEP_PROGRESS: Int
-    val progressBarCounter = ProgressBarCounter(ProgressBarCounter.DEFAULT_INITIAL_STEP_NUMBER_NEW_SESSION_FLOW)
+    val progressBarCounter = ProgressBarCounter(4) // we got 3 basic steps in the flow (progress bar should have 1 more to look better)
     private var currentProgressStep = 0
     private var backPressedListener: BackPressedListener? = null
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/common/BaseWizardNavigator.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/common/BaseWizardNavigator.kt
@@ -15,6 +15,7 @@ abstract class BaseWizardNavigator(
     }
 
     protected abstract val STEP_PROGRESS: Int
+    open var MAX_PROGRESS = 40
     private var currentProgressStep = 0
     private var backPressedListener: BackPressedListener? = null
 
@@ -44,6 +45,7 @@ abstract class BaseWizardNavigator(
     protected fun updateProgressBarView() {
         val progressBar = mViewMvc.rootView?.findViewById<ProgressBar>(R.id.progress_bar)
         progressBar?.progress = currentProgressStep * STEP_PROGRESS
+        progressBar?.max = MAX_PROGRESS
     }
 
     protected fun goToFragment(fragment: Fragment) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/common/BaseWizardNavigator.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/common/BaseWizardNavigator.kt
@@ -4,6 +4,7 @@ import android.widget.ProgressBar
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import io.lunarlogic.aircasting.R
+import io.lunarlogic.aircasting.lib.ProgressBarCounter
 
 abstract class BaseWizardNavigator(
     private val mViewMvc: ViewMvc,
@@ -15,7 +16,7 @@ abstract class BaseWizardNavigator(
     }
 
     protected abstract val STEP_PROGRESS: Int
-    open var MAX_PROGRESS = 40
+    val progressBarCounter = ProgressBarCounter(ProgressBarCounter.DEFAULT_INITIAL_STEP_NUMBER_NEW_SESSION_FLOW)
     private var currentProgressStep = 0
     private var backPressedListener: BackPressedListener? = null
 
@@ -45,7 +46,7 @@ abstract class BaseWizardNavigator(
     protected fun updateProgressBarView() {
         val progressBar = mViewMvc.rootView?.findViewById<ProgressBar>(R.id.progress_bar)
         progressBar?.progress = currentProgressStep * STEP_PROGRESS
-        progressBar?.max = MAX_PROGRESS
+        progressBar?.max = progressBarCounter.currentProgressMax
     }
 
     protected fun goToFragment(fragment: Fragment) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/create_account/CreateAccountViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/create_account/CreateAccountViewMvcImpl.kt
@@ -32,7 +32,6 @@ class CreateAccountViewMvcImpl : BaseObservableViewMvc<CreateAccountViewMvc.List
         val progressBarFrame = rootView?.findViewById<FrameLayout>(R.id.progress_bar_frame)
         if (!settings.onboardingDisplayed()) {
             progressBarFrame?.visibility = View.VISIBLE
-            settings.onboardingAccepted()
         } else {
             progressBarFrame?.visibility = View.GONE
         }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/login/LoginController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/login/LoginController.kt
@@ -17,7 +17,7 @@ import io.lunarlogic.aircasting.screens.login.LoginService
 class  LoginController(
     private val mContextActivity: AppCompatActivity,
     private val mViewMvc: LoginViewMvc,
-    mSettings: Settings,
+    private val mSettings: Settings,
     mApiServiceFactory: ApiServiceFactory,
     private val fragmentManager: FragmentManager
 ) : LoginViewMvc.Listener,
@@ -32,6 +32,9 @@ class  LoginController(
 
     fun onStop() {
         mViewMvc.unregisterListener(this)
+        if(!mSettings.onboardingDisplayed()) {
+            mSettings.onboardingAccepted()
+        }
     }
 
     override fun onLoginClicked(username: String, password: String) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/login/LoginViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/login/LoginViewMvcImpl.kt
@@ -28,10 +28,6 @@ class LoginViewMvcImpl : BaseObservableViewMvc<LoginViewMvc.Listener>, LoginView
             onForgotPasswordClicked()
         }
 
-        if (!settings.onboardingDisplayed()) {
-            rootView?.progress_bar_frame?.visibility = View.VISIBLE
-        }
-
         val progressBarFrame = rootView?.findViewById<FrameLayout>(R.id.progress_bar_frame)
         if (!settings.onboardingDisplayed()) {
             progressBarFrame?.visibility = View.VISIBLE

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/NewSessionController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/NewSessionController.kt
@@ -14,10 +14,7 @@ import io.lunarlogic.aircasting.database.repositories.SessionsRepository
 import io.lunarlogic.aircasting.events.*
 import io.lunarlogic.aircasting.exceptions.BluetoothNotSupportedException
 import io.lunarlogic.aircasting.exceptions.ErrorHandler
-import io.lunarlogic.aircasting.lib.ResultCodes
-import io.lunarlogic.aircasting.lib.Settings
-import io.lunarlogic.aircasting.lib.areLocationServicesOn
-import io.lunarlogic.aircasting.lib.safeRegister
+import io.lunarlogic.aircasting.lib.*
 import io.lunarlogic.aircasting.location.LocationHelper
 import io.lunarlogic.aircasting.permissions.PermissionsManager
 import io.lunarlogic.aircasting.screens.new_session.choose_location.ChooseLocationViewMvc
@@ -81,13 +78,13 @@ class NewSessionController(
 
     private fun setupProgressMax() {
         if (!mContextActivity.areLocationServicesOn()) {
-            wizardNavigator.MAX_PROGRESS += 10
+            wizardNavigator.progressBarCounter.increaseMaxProgress(ProgressBarCounter.ADDITIONAL_STEPS_LOCATION_OFF)
         }
         if (settings.areMapsDisabled()) {
-            wizardNavigator.MAX_PROGRESS += 10
+            wizardNavigator.progressBarCounter.increaseMaxProgress(ProgressBarCounter.ADDITIONAL_STEPS_DISABLED_MAPS)
         }
         if (!bluetoothManager.isBluetoothEnabled()) {
-            wizardNavigator.MAX_PROGRESS += 10
+            wizardNavigator.progressBarCounter.increaseMaxProgress(ProgressBarCounter.ADDITIONAL_STEPS_BLUETOOTH_OFF)
         }
 
     }
@@ -141,7 +138,7 @@ class NewSessionController(
 
     override fun onBluetoothDeviceSelected() {
         try {
-            wizardNavigator.MAX_PROGRESS += 30
+            wizardNavigator.progressBarCounter.increaseMaxProgress(ProgressBarCounter.ADDITIONAL_STEPS_BLUETOOTH_DEVICE)
             if (bluetoothManager.isBluetoothEnabled()) {
                 wizardNavigator.goToTurnOnAirBeam(sessionType, this)
                 return

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/NewSessionController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/NewSessionController.kt
@@ -78,13 +78,13 @@ class NewSessionController(
 
     private fun setupProgressMax() {
         if (!mContextActivity.areLocationServicesOn()) {
-            wizardNavigator.progressBarCounter.increaseMaxProgress(ProgressBarCounter.ADDITIONAL_STEPS_LOCATION_OFF)
+            wizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
         }
         if (settings.areMapsDisabled()) {
-            wizardNavigator.progressBarCounter.increaseMaxProgress(ProgressBarCounter.ADDITIONAL_STEPS_DISABLED_MAPS)
+            wizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
         }
         if (!bluetoothManager.isBluetoothEnabled()) {
-            wizardNavigator.progressBarCounter.increaseMaxProgress(ProgressBarCounter.ADDITIONAL_STEPS_BLUETOOTH_OFF)
+            wizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
         }
 
     }
@@ -138,7 +138,7 @@ class NewSessionController(
 
     override fun onBluetoothDeviceSelected() {
         try {
-            wizardNavigator.progressBarCounter.increaseMaxProgress(ProgressBarCounter.ADDITIONAL_STEPS_BLUETOOTH_DEVICE)
+            wizardNavigator.progressBarCounter.increaseMaxProgress(4) // 4 additional steps in flow
             if (bluetoothManager.isBluetoothEnabled()) {
                 wizardNavigator.goToTurnOnAirBeam(sessionType, this)
                 return

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/NewSessionController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/NewSessionController.kt
@@ -77,16 +77,7 @@ class NewSessionController(
     }
 
     private fun setupProgressMax() {
-        if (!mContextActivity.areLocationServicesOn()) {
-            wizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
-        }
-        if (settings.areMapsDisabled()) {
-            wizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
-        }
-        if (!bluetoothManager.isBluetoothEnabled()) {
-            wizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
-        }
-
+        wizardNavigator.setupProgressBarMax(!mContextActivity.areLocationServicesOn(), settings.areMapsDisabled(), !bluetoothManager.isBluetoothEnabled())
     }
 
     fun onStop() {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/NewSessionController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/new_session/NewSessionController.kt
@@ -3,9 +3,7 @@ package io.lunarlogic.aircasting.screens.new_session
 import android.app.Activity
 import android.app.Activity.RESULT_OK
 import android.bluetooth.BluetoothAdapter
-import android.content.Context
 import android.content.Intent
-import android.location.LocationManager
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat.startActivity
@@ -72,12 +70,26 @@ class NewSessionController(
 
     fun onCreate() {
         EventBus.getDefault().safeRegister(this);
+        setupProgressMax()
 
         if (permissionsManager.locationPermissionsGranted(mContextActivity) || areMapsDisabled()) {
             goToFirstStep()
         } else {
             permissionsManager.requestLocationPermissions(mContextActivity)
         }
+    }
+
+    private fun setupProgressMax() {
+        if (!mContextActivity.areLocationServicesOn()) {
+            wizardNavigator.MAX_PROGRESS += 10
+        }
+        if (settings.areMapsDisabled()) {
+            wizardNavigator.MAX_PROGRESS += 10
+        }
+        if (!bluetoothManager.isBluetoothEnabled()) {
+            wizardNavigator.MAX_PROGRESS += 10
+        }
+
     }
 
     fun onStop() {
@@ -129,6 +141,7 @@ class NewSessionController(
 
     override fun onBluetoothDeviceSelected() {
         try {
+            wizardNavigator.MAX_PROGRESS += 30
             if (bluetoothManager.isBluetoothEnabled()) {
                 wizardNavigator.goToTurnOnAirBeam(sessionType, this)
                 return

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/onboarding/OnboardingController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/onboarding/OnboardingController.kt
@@ -38,6 +38,7 @@ class OnboardingController(
     }
 
     fun onCreate() {
+        wizardNavigator.setupProgressBarMax()
         wizardNavigator.goToGetStarted(this)
         mViewMvc.hideProgressBar()
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/onboarding/OnboardingWizardNavigator.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/onboarding/OnboardingWizardNavigator.kt
@@ -1,7 +1,9 @@
 package io.lunarlogic.aircasting.screens.onboarding
 
+import android.widget.ProgressBar
 import androidx.fragment.app.FragmentManager
 import io.lunarlogic.aircasting.R
+import io.lunarlogic.aircasting.lib.ProgressBarCounter
 import io.lunarlogic.aircasting.screens.common.BaseWizardNavigator
 import io.lunarlogic.aircasting.screens.onboarding.get_started.OnboardingGetStartedFragment
 import io.lunarlogic.aircasting.screens.onboarding.get_started.OnboardingGetStartedViewMvc
@@ -45,5 +47,11 @@ class OnboardingWizardNavigator(
         val fragment = OnboardingYourPrivacyFragment()
         fragment.listener = listener
         goToFragment(fragment)
+    }
+
+    fun setupProgressBarMax() {
+        progressBarCounter.currentProgressMax = ProgressBarCounter.DEFAULT_ONBOARDING_STEP_NUMBER * STEP_PROGRESS
+        val progressBar = mViewMvc.rootView?.findViewById<ProgressBar>(R.id.progress_bar)
+        progressBar?.max = progressBarCounter.currentProgressMax
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/settings/clear_sd_card/ClearSDCardController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/settings/clear_sd_card/ClearSDCardController.kt
@@ -50,6 +50,16 @@ class ClearSDCardController(
     fun onCreate() {
         EventBus.getDefault().safeRegister(this)
 
+        setupProgressBarMax()
+
+        if (mPermissionsManager.locationPermissionsGranted(mContextActivity)) {
+            goToFirstStep()
+        } else {
+            mPermissionsManager.requestLocationPermissions(mContextActivity)
+        }
+    }
+
+    private fun setupProgressBarMax() {
         mWizardNavigator.progressBarCounter.increaseMaxProgress(4) // 4 additional steps by default because we always have bluetooth device here
         if (!mContextActivity.areLocationServicesOn()) {
             mWizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
@@ -59,12 +69,6 @@ class ClearSDCardController(
         }
         if (!mBluetoothManager.isBluetoothEnabled()) {
             mWizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
-        }
-
-        if (mPermissionsManager.locationPermissionsGranted(mContextActivity)) {
-            goToFirstStep()
-        } else {
-            mPermissionsManager.requestLocationPermissions(mContextActivity)
         }
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/settings/clear_sd_card/ClearSDCardController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/settings/clear_sd_card/ClearSDCardController.kt
@@ -60,16 +60,7 @@ class ClearSDCardController(
     }
 
     private fun setupProgressBarMax() {
-        mWizardNavigator.progressBarCounter.increaseMaxProgress(4) // 4 additional steps by default because we always have bluetooth device here
-        if (!mContextActivity.areLocationServicesOn()) {
-            mWizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
-        }
-        if (mSettings.areMapsDisabled()) {
-            mWizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
-        }
-        if (!mBluetoothManager.isBluetoothEnabled()) {
-            mWizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
-        }
+        mWizardNavigator.setupProgressBarMax(!mContextActivity.areLocationServicesOn(), mSettings.areMapsDisabled(), !mBluetoothManager.isBluetoothEnabled())
     }
 
     fun onStop() {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/settings/clear_sd_card/ClearSDCardController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/settings/clear_sd_card/ClearSDCardController.kt
@@ -50,6 +50,17 @@ class ClearSDCardController(
     fun onCreate() {
         EventBus.getDefault().safeRegister(this)
 
+        mWizardNavigator.progressBarCounter.increaseMaxProgress(4) // 4 additional steps by default because we always have bluetooth device here
+        if (!mContextActivity.areLocationServicesOn()) {
+            mWizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
+        }
+        if (mSettings.areMapsDisabled()) {
+            mWizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
+        }
+        if (!mBluetoothManager.isBluetoothEnabled()) {
+            mWizardNavigator.progressBarCounter.increaseMaxProgress(1) // 1 additional step in flow
+        }
+
         if (mPermissionsManager.locationPermissionsGranted(mContextActivity)) {
             goToFirstStep()
         } else {
@@ -149,8 +160,6 @@ class ClearSDCardController(
 
     @Subscribe
     fun onMessageEvent(event: AirBeamConnectionFailedEvent) {
-        // TODO: remove following and handle error
-//        mWizardNavigator.goToSDCardCleared(this)
         onBackPressed()
         val dialog = AircastingAlertDialog(mFragmentManager, mContextActivity.resources.getString(R.string.bluetooth_failed_connection_alert_header), mContextActivity.resources.getString(R.string.bluetooth_failed_connection_alert_description))
         dialog.show()

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/settings/clear_sd_card/ClearSDCardWizardNavigator.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/settings/clear_sd_card/ClearSDCardWizardNavigator.kt
@@ -25,7 +25,7 @@ class ClearSDCardWizardNavigator(
     fragmentManager,
     R.id.clear_sd_card_fragment_container
 ) {
-    override val STEP_PROGRESS = 4
+    override val STEP_PROGRESS = 15
 
     fun goToTurnOnLocationServices(
         listener: TurnOnLocationServicesViewMvc.Listener
@@ -85,4 +85,6 @@ class ClearSDCardWizardNavigator(
         fragment.listener = listener
         goToFragment(fragment)
     }
+
+
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/settings/clear_sd_card/ClearSDCardWizardNavigator.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/settings/clear_sd_card/ClearSDCardWizardNavigator.kt
@@ -85,6 +85,4 @@ class ClearSDCardWizardNavigator(
         fragment.listener = listener
         goToFragment(fragment)
     }
-
-
 }

--- a/app/src/main/res/layout/activity_new_session.xml
+++ b/app/src/main/res/layout/activity_new_session.xml
@@ -29,7 +29,6 @@
             android:layout_height="8dp"
             android:layout_margin="0dp"
             android:indeterminate="false"
-            android:max="30"
             android:progressDrawable="@drawable/curved_progress_bar"
             />
 

--- a/app/src/main/res/layout/activity_new_session.xml
+++ b/app/src/main/res/layout/activity_new_session.xml
@@ -29,6 +29,7 @@
             android:layout_height="8dp"
             android:layout_margin="0dp"
             android:indeterminate="false"
+            android:max="30"
             android:progressDrawable="@drawable/curved_progress_bar"
             />
 


### PR DESCRIPTION
https://trello.com/c/29pfMpDY/1154-fix-progress-bar-to-show-correct-progress

The idea:
- we got minimum number of steps that we have to go through when creating session (Phone mic session- 3 steps)
- basically we set the maximum value of progress on ProgressBar on 40 (10 per step + 10 because it looks better)
- in NewSessionController we increase the MAX_PROGRESS value for each step we have to add to our flow (+1 if locations is off, +1 if Bluetooth is off, +1 if maps are disabled (turn off location services screen), +3 screens if DeviceType==Bluetto device)