### PR TITLE
Fix deleting measurements

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
@@ -50,11 +50,17 @@ interface MeasurementDao {
     @Query("DELETE FROM measurements")
     fun deleteAll()
 
-    @Query("DELETE FROM measurements WHERE time <= datetime('now', '-1 day') AND session_id in (:sessionIds)")
-    fun delete(sessionIds: List<Long>)
+    @Query("DELETE FROM measurements WHERE session_id in (:sessionIds) AND time < :lastExpectedMeasurementDate ")
+    fun delete(sessionIds: List<Long>, lastExpectedMeasurementDate: Date)
+
+    @Query("SELECT * FROM measurements WHERE session_id in (:sessionIds) ORDER BY time DESC LIMIT :limit")
+    fun getLastTwentyFourHours(sessionIds: List<Long>, limit: Int): List<MeasurementDBObject?>
+
+    @Query("SELECT * FROM measurements WHERE session_id in (:sessionIds) ORDER BY time DESC")
+    fun getAllMeasurementsBySessionIds(sessionIds: List<Long>): List<MeasurementDBObject?>
 
     @Transaction
-    fun deleteInTransaction(sessionIds: List<Long>) {
-        delete(sessionIds)
+    fun deleteInTransaction(sessionIds: List<Long>, lastExpectedMeasurementDate: Date) {
+        delete(sessionIds, lastExpectedMeasurementDate )
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
@@ -56,9 +56,6 @@ interface MeasurementDao {
     @Query("SELECT * FROM measurements WHERE session_id in (:sessionIds) ORDER BY time DESC LIMIT :limit")
     fun getLastTwentyFourHours(sessionIds: List<Long>, limit: Int): List<MeasurementDBObject?>
 
-    @Query("SELECT * FROM measurements WHERE session_id in (:sessionIds) ORDER BY time DESC")
-    fun getAllMeasurementsBySessionIds(sessionIds: List<Long>): List<MeasurementDBObject?>
-
     @Transaction
     fun deleteInTransaction(sessionIds: List<Long>, lastExpectedMeasurementDate: Date) {
         delete(sessionIds, lastExpectedMeasurementDate )

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
@@ -50,14 +50,14 @@ interface MeasurementDao {
     @Query("DELETE FROM measurements")
     fun deleteAll()
 
-    @Query("DELETE FROM measurements WHERE session_id in (:sessionIds) AND time < :lastExpectedMeasurementDate ")
-    fun delete(sessionIds: List<Long>, lastExpectedMeasurementDate: Date)
+    @Query("DELETE FROM measurements WHERE session_id=:sessionId AND time < :lastExpectedMeasurementDate ")
+    fun delete(sessionId: Long, lastExpectedMeasurementDate: Date)
 
-    @Query("SELECT * FROM measurements WHERE session_id in (:sessionIds) ORDER BY time DESC LIMIT :limit")
-    fun getLastTwentyFourHours(sessionIds: List<Long>, limit: Int): List<MeasurementDBObject?>
+    @Query("SELECT * FROM measurements WHERE session_id=:sessionId ORDER BY time DESC LIMIT :limit")
+    fun getLastMeasurements(sessionId: Long, limit: Int): List<MeasurementDBObject?>
 
     @Transaction
-    fun deleteInTransaction(sessionIds: List<Long>, lastExpectedMeasurementDate: Date) {
-        delete(sessionIds, lastExpectedMeasurementDate )
+    fun deleteInTransaction(sessionId: Long, lastExpectedMeasurementDate: Date) {
+        delete(sessionId, lastExpectedMeasurementDate )
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
@@ -46,15 +46,15 @@ class MeasurementsRepository {
         return measurement?.time
     }
 
-    fun getLastMeasurements(sessionIds: List<Long>, limit: Int): List<MeasurementDBObject?> {
-        return mDatabase.measurements().getLastTwentyFourHours(sessionIds, limit)
+    fun getLastMeasurements(sessionId: Long, limit: Int): List<MeasurementDBObject?> {
+        return mDatabase.measurements().getLastMeasurements(sessionId, limit)
     }
 
-    fun deleteMeasurements(
-        sessionIds: List<Long>,
+    fun deleteMeasurementsOlderThen(
+        sessionId: Long,
         lastExpectedMeasurementTime: Date
     ) {
-        mDatabase.measurements().deleteInTransaction(sessionIds, lastExpectedMeasurementTime)
+        mDatabase.measurements().deleteInTransaction(sessionId, lastExpectedMeasurementTime)
     }
 
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
@@ -46,10 +46,15 @@ class MeasurementsRepository {
         return measurement?.time
     }
 
-    fun deleteMeasurements(sessionIds: List<Long>) {
-        mDatabase.runInTransaction {
-            mDatabase.measurements().deleteInTransaction(sessionIds)
-        }
+    fun getLastMeasurements(sessionIds: List<Long>, limit: Int): List<MeasurementDBObject?> {
+        return mDatabase.measurements().getLastTwentyFourHours(sessionIds, limit)
+    }
+
+    fun deleteMeasurements(
+        sessionIds: List<Long>,
+        lastExpectedMeasurementTime: Date
+    ) {
+        mDatabase.measurements().deleteInTransaction(sessionIds, lastExpectedMeasurementTime)
     }
 
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
@@ -8,19 +8,21 @@ import java.util.*
 class RemoveOldMeasurementsService() {
     private val measurementRepository = MeasurementsRepository()
     private val sessionRepository = SessionsRepository()
-    private val TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT = 1440
+    private val TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT = 24 * 60
 
     fun removeMeasurementsFromSessions() {
         val fixedSessionsIds = sessionRepository.sessionsIdsByType(Session.Type.FIXED)
-        val lastMeasurements = measurementRepository.getLastMeasurements(fixedSessionsIds, TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT)
-        if (checkIfDeleteMeasurements(lastMeasurements.size)) {
-            val lastExpectedMeasurement = lastMeasurements.last()
-            val lastExpectedMeasurementTime: Date = lastExpectedMeasurement?.time!!
-            measurementRepository.deleteMeasurements(fixedSessionsIds, lastExpectedMeasurementTime)
+        fixedSessionsIds.forEach {fixedSessionId ->
+            val lastMeasurements = measurementRepository.getLastMeasurements(fixedSessionId, TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT)
+            if (shouldDeleteMeasurements(lastMeasurements.size)) {
+                val lastExpectedMeasurement = lastMeasurements.last()
+                val lastExpectedMeasurementTime: Date = lastExpectedMeasurement?.time!!
+                measurementRepository.deleteMeasurementsOlderThen(fixedSessionId, lastExpectedMeasurementTime)
+            }
         }
     }
 
-    private fun checkIfDeleteMeasurements(measurementsCount: Int): Boolean {
+    private fun shouldDeleteMeasurements(measurementsCount: Int): Boolean {
         return measurementsCount == TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
@@ -3,13 +3,24 @@ package io.lunarlogic.aircasting.networking.services
 import io.lunarlogic.aircasting.database.repositories.MeasurementsRepository
 import io.lunarlogic.aircasting.database.repositories.SessionsRepository
 import io.lunarlogic.aircasting.models.Session
+import java.util.*
 
 class RemoveOldMeasurementsService() {
     private val measurementRepository = MeasurementsRepository()
     private val sessionRepository = SessionsRepository()
+    private val TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT = 1440
 
     fun removeMeasurementsFromSessions() {
         val fixedSessionsIds = sessionRepository.sessionsIdsByType(Session.Type.FIXED)
-        measurementRepository.deleteMeasurements(fixedSessionsIds)
+        val lastMeasurements = measurementRepository.getLastMeasurements(fixedSessionsIds, TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT)
+        if (checkIfDeleteMeasurements(lastMeasurements.size)) {
+            val lastExpectedMeasurement = lastMeasurements.last()
+            val lastExpectedMeasurementTime: Date = lastExpectedMeasurement?.time!!
+            measurementRepository.deleteMeasurements(fixedSessionsIds, lastExpectedMeasurementTime)
+        }
+    }
+
+    private fun checkIfDeleteMeasurements(measurementsCount: Int): Boolean {
+        return measurementsCount == TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/SessionsSyncService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/SessionsSyncService.kt
@@ -107,7 +107,7 @@ class SessionsSyncService {
                                 delete(body.deleted)
                                 upload(body.upload)
                                 download(body.download)
-//                                removeOldMeasurements()
+                                removeOldMeasurements()
 
                                 onSuccessCallback?.invoke()
                             }


### PR DESCRIPTION
**Important changes:**

- I've added a function in order to get the last 1440 (24h) measurements from fixed sessions 
- I checked the date of the oldest one and passed this date to the measurements repository
- I've added deleting measurements from fixed sessions, but only older than this date

And it works for me. For testing how it works do it on your account and HabitatMap as well and:
- follow the below-listed sessions:
**4406, 766E, Office 2, Office**
-navigate to the fixed tab, pull down, and wait for the data to refresh

It should look good 🐱 if don't - try to reinstall the app as we established today during our morning standup 📴 

<img width="310" alt="Screenshot 2021-03-04 at 17 50 29" src="https://user-images.githubusercontent.com/23139274/110000167-49be7000-7d13-11eb-863d-acc827aa09f0.png">

