### PR TITLE
Loader in the measurements table in the session card do not hide if two sessions are being recorded

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/SessionsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/SessionsRepository.kt
@@ -55,8 +55,8 @@ class SessionsRepository {
     }
 
     fun mobileSessionAlreadyExistsForDeviceId(deviceId: String): Boolean {
-        return mDatabase.sessions()
-            .loadSessionByDeviceIdStatusAndType(deviceId, Session.Status.RECORDING, Session.Type.MOBILE) != null
+        return mDatabase.sessions().loadSessionByDeviceIdStatusAndType(deviceId, Session.Status.RECORDING, Session.Type.MOBILE) != null ||
+                mDatabase.sessions().loadSessionByDeviceIdStatusAndType(deviceId, Session.Status.DISCONNECTED, Session.Type.MOBILE) != null
     }
 
     fun disconnectMobileBluetoothSessions() {


### PR DESCRIPTION
https://trello.com/c/AdIcqVLW/1156-loader-in-the-measurements-table-in-the-session-card-do-not-hide-if-two-sessions-are-being-recorded