### PR TITLE
dashboard > tabs: the padding to the right of the fixed tab should match the padding to the left of the following tab. currently, "Fixed" is too close to the edge of the screen.

### DIFF
--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -18,7 +18,7 @@
             app:tabMode="scrollable"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="parent">
-        </com.google.android.material.tabs.TabLayout>
+            app:layout_constraintBottom_toTopOf="parent"
+            android:paddingEnd="@dimen/keyline_4" />
     </androidx.viewpager.widget.ViewPager>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
https://trello.com/c/1TLoS5uC/1158-dashboard-tabs-the-padding-to-the-right-of-the-fixed-tab-should-match-the-padding-to-the-left-of-the-following-tab-currently-fix