### PR TITLE
onboarding map and measure header line height increased

### DIFF
--- a/app/src/main/res/layout/onboarding_measure_and_map.xml
+++ b/app/src/main/res/layout/onboarding_measure_and_map.xml
@@ -40,7 +40,7 @@
         android:layout_marginEnd="@dimen/keyline_8"
         android:textColor="@color/aircasting_green"
         android:textSize="@dimen/text_size_xxl"
-        style="@style/TextAppearance.Aircasting.NewSessionSteps.Headline1"
+        style="@style/TextAppearance.Aircasting.OnboardingMapAndMeasure.Headline1"
         app:layout_constraintTop_toBottomOf="@id/onboarding_measure_and_map_image"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -274,6 +274,12 @@
         <item name="lineHeight">@dimen/keyline_5</item>
     </style>
 
+    <style name="TextAppearance.Aircasting.OnboardingMapAndMeasure.Headline1" parent="@style/TextAppearance.AppCompat">
+        <item name="android:fontFamily">@font/moderat_trial_bold</item>
+        <item name="android:textColor">?attr/colorPrimary</item>
+        <item name="android:textSize">@dimen/text_size_xl</item>
+        <item name="lineHeight">@dimen/line_height_xxl</item>
+    </style>
     <!-- Styles -->
 
     <!-- Buttons -->


### PR DESCRIPTION
Fix to this task:
https://trello.com/c/dS4zt1oR/1162-decrease-line-heights-in-the-blue-headers-in-the-new-session-flow-screens-turn-on-bluetooth-airbeam-and-so-on
Michael was ok with given line height throughout the app except of Onboarding- Measure and Map screen. I increased the line height there.