### PR TITLE
Not stretching borders on measurement table values

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -154,8 +154,7 @@ class MeasurementsTableContainer {
 
     private fun resetMeasurementHeader(headerView: View) {
         val headerTextView = headerView.findViewById<TextView>(R.id.measurement_header)
-        headerTextView.setTypeface(null, Typeface.NORMAL)
-        headerTextView.setTextColor(mHeaderColor)
+        headerTextView.setTextAppearance(mContext, R.style.TextAppearance_Aircasting_MeasurementsTableHeader)
     }
 
     private fun markMeasurementHeaderAsSelected(stream: MeasurementStream) {
@@ -168,8 +167,7 @@ class MeasurementsTableContainer {
     }
 
     private fun markMeasurementHeaderAsSelected(headerTextView: TextView) {
-        headerTextView.setTypeface(null, Typeface.BOLD)
-        headerTextView.setTextColor(mSelectedHeaderColor)
+        headerTextView.setTextAppearance(mContext, R.style.TextAppearance_Aircasting_MeasurementsTableHeaderSelected)
     }
 
     private fun markMeasurementValueAsSelected(stream: MeasurementStream) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -2,12 +2,10 @@ package io.lunarlogic.aircasting.screens.session_view
 
 import android.content.Context
 import android.graphics.Typeface
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
-import android.widget.ImageView
-import android.widget.TableLayout
-import android.widget.TableRow
-import android.widget.TextView
+import android.widget.*
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.forEach
 import androidx.core.view.get
@@ -36,9 +34,6 @@ class MeasurementsTableContainer {
     private val mMeasurementHeaders: TableRow?
     private var mMeasurementValues: TableRow? = null
 
-    private val mHeaderColor: Int
-    private val mSelectedHeaderColor: Int
-
     private var mSessionPresenter: SessionPresenter? = null
     private var mOnMeasurementStreamChanged: ((MeasurementStream) -> Unit)? = null
 
@@ -62,9 +57,6 @@ class MeasurementsTableContainer {
         if (mDisplayValues) {
             mMeasurementValues = rootView?.measurement_values
         }
-
-        mHeaderColor = ResourcesCompat.getColor(mContext.resources, R.color.aircasting_grey_700, null)
-        mSelectedHeaderColor = ResourcesCompat.getColor(mContext.resources, R.color.aircasting_dark_blue, null)
     }
 
     fun makeSelectable(displayValues: Boolean = true) {
@@ -157,7 +149,7 @@ class MeasurementsTableContainer {
 
     private fun resetSensorSelection() {
         mMeasurementHeaders?.forEach { resetMeasurementHeader(it) }
-        mMeasurementValues?.forEach { it.background = null }
+        mMeasurementValues?.forEach { resetValueViewBorder(it as LinearLayout) }
     }
 
     private fun resetMeasurementHeader(headerView: View) {
@@ -185,9 +177,9 @@ class MeasurementsTableContainer {
         val color = mLastMeasurementColors[stream.sensorName]
 
         try {
-            val valueView = mMeasurementValues?.get(index)
-            if (valueView != null && color != null) {
-                valueView.background = SelectedSensorBorder(color)
+            val valueViewContainer: LinearLayout = mMeasurementValues?.get(index) as LinearLayout
+            if (valueViewContainer != null && color != null) {
+                setValueViewBorder(valueViewContainer, color)
             }
         } catch(e: IndexOutOfBoundsException) {}
     }
@@ -198,20 +190,19 @@ class MeasurementsTableContainer {
         val color = MeasurementColor.forMap(mContext, measurementValue, mSessionPresenter?.sensorThresholdFor(stream))
         mLastMeasurementColors[stream.sensorName] = color
 
-        val valueView = renderValueView(measurementValue, color)
-
-        mMeasurementValues?.addView(valueView)
+        val valueViewContainer = renderValueView(measurementValue, color)
+        mMeasurementValues?.addView(valueViewContainer)
         
         if (mSelectable) {
             if (stream == mSessionPresenter?.selectedStream) {
-                valueView.background = SelectedSensorBorder(color)
+                setValueViewBorder(valueViewContainer, color)
             }
 
-            valueView.setOnClickListener {
+            valueViewContainer.setOnClickListener {
                 onMeasurementClicked(stream)
 
                 markMeasurementHeaderAsSelected(stream)
-                valueView.background = SelectedSensorBorder(color)
+                setValueViewBorder(valueViewContainer, color)
             }
         }
     }
@@ -228,7 +219,7 @@ class MeasurementsTableContainer {
         return mSessionPresenter?.isFixed() == false && mSessionPresenter?.isDisconnected() == true
     }
 
-    private fun renderValueView(measurementValue: Double, color: Int): View {
+    private fun renderValueView(measurementValue: Double, color: Int): LinearLayout {
         val valueView = mLayoutInflater.inflate(R.layout.measurement_value, null, false)
 
         val circleView = valueView.findViewById<ImageView>(R.id.circle_indicator)
@@ -244,6 +235,21 @@ class MeasurementsTableContainer {
         }
 
         valueView.background = null
-        return valueView
+
+        val containerLayout = LinearLayout(mContext)
+        containerLayout.gravity = Gravity.CENTER
+        containerLayout.addView(valueView)
+
+        return containerLayout
+    }
+
+    private fun setValueViewBorder(valueViewContainer: LinearLayout, color: Int) {
+        val valueView = valueViewContainer.getChildAt(0)
+        valueView.background = SelectedSensorBorder(color)
+    }
+
+    private fun resetValueViewBorder(valueViewContainer: LinearLayout) {
+        val valueView = valueViewContainer.getChildAt(0)
+        valueView.background = null
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SelectedSensorBorder.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SelectedSensorBorder.kt
@@ -3,8 +3,8 @@ package io.lunarlogic.aircasting.screens.session_view
 import android.graphics.drawable.GradientDrawable
 
 class SelectedSensorBorder: GradientDrawable {
-    private val BORDER_WIDTH = 4
-    private val CORNER_RADIUS = 35f
+    private val BORDER_WIDTH = 3
+    private val CORNER_RADIUS = 23f
 
     constructor(color: Int): super() {
         setStroke(BORDER_WIDTH, color)

--- a/app/src/main/res/layout/measurement_value.xml
+++ b/app/src/main/res/layout/measurement_value.xml
@@ -13,7 +13,7 @@
         android:layout_height="6dp"
         android:adjustViewBounds="true"
         android:scaleType="fitXY"
-        android:layout_marginStart="6dp"
+        android:layout_marginStart="@dimen/keyline_4"
         android:tint="@color/aircasting_pink" />
 
     <TextView
@@ -22,7 +22,8 @@
         android:layout_height="wrap_content"
         android:textSize="@dimen/text_size_xs"
         android:textColor="@color/aircasting_grey_700"
-        android:layout_marginStart="3dp"
-        android:padding="@dimen/keyline_1"/>
+        android:layout_marginEnd="8dp"
+        android:paddingStart="3dp"
+        android:padding = "@dimen/keyline_1" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/measurement_value.xml
+++ b/app/src/main/res/layout/measurement_value.xml
@@ -9,8 +9,8 @@
     <ImageView
         android:id="@+id/circle_indicator"
         app:srcCompat="@drawable/ic_circle"
-        android:layout_width="6dp"
-        android:layout_height="6dp"
+        android:layout_width="7dp"
+        android:layout_height="7dp"
         android:adjustViewBounds="true"
         android:scaleType="fitXY"
         android:layout_marginStart="@dimen/keyline_4"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -280,6 +280,19 @@
         <item name="android:textSize">@dimen/text_size_xl</item>
         <item name="lineHeight">@dimen/line_height_xxl</item>
     </style>
+
+    <style name="TextAppearance.Aircasting.MeasurementsTableHeaderSelected" parent="@style/TextAppearance.Aircasting.Body2">
+        <item name="android:textColor">@color/aircasting_dark_blue</item>
+        <item name="android:fontFamily">@font/muli_semi_bold</item>
+        <item name="android:textSize">@dimen/text_size_xs</item>
+    </style>
+
+    <style name="TextAppearance.Aircasting.MeasurementsTableHeader" parent="@style/TextAppearance.Aircasting.Body2">
+        <item name="android:textColor">@color/aircasting_grey_700</item>
+        <item name="android:fontFamily">@font/muli_regular</item>
+        <item name="android:textSize">@dimen/text_size_xs</item>
+    </style>
+
     <!-- Styles -->
 
     <!-- Buttons -->


### PR DESCRIPTION
This was supposed to be only about borders but I decided to make some other changes to adjust measurements table to the designs. Changes made:

- borders are not being stretched if there are less than 5 streams
- border radius is smaller
- border width is smaller
- colorful circle is bigger
- left and right margins of measurement value are bigger
- font of selected stream header is semi bold, not bold