### PR TITLE
Delete measurements by streams

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurement_streams.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurement_streams.kt
@@ -63,6 +63,9 @@ interface MeasurementStreamDao {
     @Query("SELECT * FROM measurement_streams WHERE session_id=:sessionId AND sensor_name=:sensorName")
     fun loadStreamBySessionIdAndSensorName(sessionId: Long, sensorName: String): MeasurementStreamDBObject?
 
+    @Query("SELECT id FROM measurement_streams WHERE session_id in (:sessionIds)")
+    fun getStreamsIdsBySessionIds(sessionIds: List<Long>): List<Long>
+
     @Query("DELETE FROM measurement_streams")
     fun deleteAll()
 

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
@@ -53,8 +53,8 @@ interface MeasurementDao {
     @Query("DELETE FROM measurements WHERE session_id=:sessionId AND time < :lastExpectedMeasurementDate ")
     fun delete(sessionId: Long, lastExpectedMeasurementDate: Date)
 
-    @Query("SELECT * FROM measurements WHERE session_id=:sessionId ORDER BY time DESC LIMIT :limit")
-    fun getLastMeasurements(sessionId: Long, limit: Int): List<MeasurementDBObject?>
+    @Query("SELECT * FROM measurements WHERE measurement_stream_id=:streamId ORDER BY time DESC LIMIT :limit")
+    fun getLastMeasurements(streamId: Long, limit: Int): List<MeasurementDBObject?>
 
     @Transaction
     fun deleteInTransaction(sessionId: Long, lastExpectedMeasurementDate: Date) {

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/measurements.kt
@@ -57,7 +57,7 @@ interface MeasurementDao {
     fun getLastMeasurements(streamId: Long, limit: Int): List<MeasurementDBObject?>
 
     @Transaction
-    fun deleteInTransaction(sessionId: Long, lastExpectedMeasurementDate: Date) {
-        delete(sessionId, lastExpectedMeasurementDate )
+    fun deleteInTransaction(streamId: Long, lastExpectedMeasurementDate: Date) {
+        delete(streamId, lastExpectedMeasurementDate )
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementStreamsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementStreamsRepository.kt
@@ -38,4 +38,8 @@ class MeasurementStreamsRepository {
     fun deleteMarkedForRemoval() {
         mDatabase.measurementStreams().deleteMarkedForRemoval()
     }
+
+    fun getStreamsIdsBySessionIds(sessionsIds: List<Long>): List<Long> {
+        return mDatabase.measurementStreams().getStreamsIdsBySessionIds(sessionsIds)
+    }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
@@ -51,10 +51,10 @@ class MeasurementsRepository {
     }
 
     fun deleteMeasurementsOlderThen(
-        sessionId: Long,
+        streamId: Long,
         lastExpectedMeasurementTime: Date
     ) {
-        mDatabase.measurements().deleteInTransaction(sessionId, lastExpectedMeasurementTime)
+        mDatabase.measurements().deleteInTransaction(streamId, lastExpectedMeasurementTime)
     }
 
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
@@ -46,8 +46,8 @@ class MeasurementsRepository {
         return measurement?.time
     }
 
-    fun getLastMeasurements(sessionId: Long, limit: Int): List<MeasurementDBObject?> {
-        return mDatabase.measurements().getLastMeasurements(sessionId, limit)
+    fun getLastMeasurementsForStream(streamId: Long, limit: Int): List<MeasurementDBObject?> {
+        return mDatabase.measurements().getLastMeasurements(streamId, limit)
     }
 
     fun deleteMeasurementsOlderThen(

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/MeasurementsRepository.kt
@@ -50,7 +50,7 @@ class MeasurementsRepository {
         return mDatabase.measurements().getLastMeasurements(streamId, limit)
     }
 
-    fun deleteMeasurementsOlderThen(
+    fun deleteMeasurementsOlderThan(
         streamId: Long,
         lastExpectedMeasurementTime: Date
     ) {

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
@@ -21,7 +21,7 @@ class RemoveOldMeasurementsService() {
             if (shouldDeleteMeasurements(lastMeasurements.size)) {
                 val lastExpectedMeasurement = lastMeasurements.last()
                 val lastExpectedMeasurementTime: Date = lastExpectedMeasurement?.time!!
-                measurementRepository.deleteMeasurementsOlderThen(streamId, lastExpectedMeasurementTime)
+                measurementRepository.deleteMeasurementsOlderThan(streamId, lastExpectedMeasurementTime)
             }
         }
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
@@ -2,12 +2,14 @@ package io.lunarlogic.aircasting.networking.services
 
 import io.lunarlogic.aircasting.database.repositories.MeasurementsRepository
 import io.lunarlogic.aircasting.database.repositories.SessionsRepository
+import io.lunarlogic.aircasting.database.repositories.MeasurementStreamsRepository
 import io.lunarlogic.aircasting.models.Session
 import java.util.*
 
 class RemoveOldMeasurementsService() {
     private val measurementRepository = MeasurementsRepository()
     private val sessionRepository = SessionsRepository()
+    private val measurementStreamsRepository = MeasurementStreamsRepository()
     private val TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT = 24 * 60
 
     fun removeMeasurementsFromSessions() {

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
@@ -13,6 +13,12 @@ class RemoveOldMeasurementsService() {
     private val TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT = 24 * 60
 
     fun removeMeasurementsFromSessions() {
+        // For next generations:
+        // We want to remove measurements older than 24h,
+        // but we treat 24 not like a date, but as a sum of measurements.
+        // We know that we have 60 measurements per hour,
+        // so we take 1440 last measurements for each stream in fixed sessions
+        // and we remove older than the first of them.
         val fixedSessionsIds = sessionRepository.sessionsIdsByType(Session.Type.FIXED)
         val streamsForFixedSessionsIds = measurementStreamsRepository.getStreamsIdsBySessionIds(fixedSessionsIds)
 
@@ -27,6 +33,7 @@ class RemoveOldMeasurementsService() {
     }
 
     private fun shouldDeleteMeasurements(measurementsCount: Int): Boolean {
+        // if measurementsCount is smaller than 1440 we don't want to remove anything
         return measurementsCount == TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/RemoveOldMeasurementsService.kt
@@ -14,12 +14,14 @@ class RemoveOldMeasurementsService() {
 
     fun removeMeasurementsFromSessions() {
         val fixedSessionsIds = sessionRepository.sessionsIdsByType(Session.Type.FIXED)
-        fixedSessionsIds.forEach {fixedSessionId ->
-            val lastMeasurements = measurementRepository.getLastMeasurements(fixedSessionId, TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT)
+        val streamsForFixedSessionsIds = measurementStreamsRepository.getStreamsIdsBySessionIds(fixedSessionsIds)
+
+        streamsForFixedSessionsIds.forEach { streamId ->
+            val lastMeasurements = measurementRepository.getLastMeasurementsForStream(streamId, TWENTY_FOUR_HOURS_MEASUREMENTS_COUNT)
             if (shouldDeleteMeasurements(lastMeasurements.size)) {
                 val lastExpectedMeasurement = lastMeasurements.last()
                 val lastExpectedMeasurementTime: Date = lastExpectedMeasurement?.time!!
-                measurementRepository.deleteMeasurementsOlderThen(fixedSessionId, lastExpectedMeasurementTime)
+                measurementRepository.deleteMeasurementsOlderThen(streamId, lastExpectedMeasurementTime)
             }
         }
     }


### PR DESCRIPTION
Important changes: 

- I've added getting and deleting measurements for each stream in a fixed session and I've replaced previous logic with that.

In order to QA that it's good to reinstall the app when you switch branch to `delete-measurements-by-streams`. I compared data for few sessions in the old app and this branch, and it looks exactly the same. 

<img width="310" alt="Screenshot 2021-03-10 at 12 35 16" src="https://user-images.githubusercontent.com/23139274/110623800-a9969a00-819d-11eb-86dc-e8806a718c69.png">
