### PR TITLE
Fixed bug outdoor sessions

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/networking/responses/UpdateSessionResponse.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/responses/UpdateSessionResponse.kt
@@ -10,6 +10,7 @@ class UpdateSessionResponse(
     val latitude: Double,
     val longitude: Double,
     val deleted: Boolean,
+    val is_indoor: Boolean,
     val contribute: Boolean,
     val version: Int,
     val streams: HashMap<String, SessionStreamResponse>

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionPresenter.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionPresenter.kt
@@ -19,6 +19,7 @@ class SessionPresenter() {
     var sessionUUID: String? = null
     var initialSensorName: String? = null
     var visibleTimeSpan: ClosedRange<Date>? = null
+    var shouldHideMap: Boolean = false
 
     constructor(
         session: Session,
@@ -35,6 +36,7 @@ class SessionPresenter() {
         if (session.tab == SessionsTab.FOLLOWING || session.tab == SessionsTab.MOBILE_ACTIVE) {
             this.chartData = ChartData(session)
         }
+        this.shouldHideMap = session.indoor
 
         if (session.tab == SessionsTab.MOBILE_ACTIVE) {
             this.loading = true

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -204,8 +204,10 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
     }
 
     protected open fun bindMapButton(sessionPresenter: SessionPresenter) {
-        if (sessionPresenter.session?.indoor == true ) {
+        if (sessionPresenter.shouldHideMap) {
             mMapButton.visibility = View.GONE
+        } else {
+            mMapButton.visibility = View.VISIBLE
         }
     }
 


### PR DESCRIPTION
I've added a new attribute to SessionPresenter: shouldHideMap - since sometimes sessionPresenter.session?.indoor didn't work properly. I'm still not sure why, but sometimes we have indoor == true in our DB and on the backend side as well, but the presenter "thought" there is false there.
Also, I've added an if-else statement in the session view. So far I didn't reproduce this bug but please double check it.
<img width="288" alt="Screenshot 2021-03-14 at 20 05 45" src="https://user-images.githubusercontent.com/23139274/111081349-28c00100-8503-11eb-8eee-57325c643aea.png">

How to QA it:

- Sign in as HabitatMap
- Go to fixed tab
- Follow a few sessions: 
"Michael Ave - Del Rey", "Queens College DEC Colocation", "Kalaheo - Kailua", "Office"
- Go to following tab
- Expand sessions and check if the map button is hidden for "Office" and shown for the rest
- Unfollow some of them and follow again, and check one more time
- If it works wait for a few minutes and check it again