### PR TITLE
Fixes SD card sync: hangs on "Updating sessions"

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/events/sessions_sync/SessionsSyncErrorEvent.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/events/sessions_sync/SessionsSyncErrorEvent.kt
@@ -1,0 +1,3 @@
+package io.lunarlogic.aircasting.events.sessions_sync
+
+class SessionsSyncErrorEvent

--- a/app/src/main/java/io/lunarlogic/aircasting/events/sessions_sync/SessionsSyncSuccessEvent.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/events/sessions_sync/SessionsSyncSuccessEvent.kt
@@ -1,0 +1,3 @@
+package io.lunarlogic.aircasting.events.sessions_sync
+
+class SessionsSyncSuccessEvent

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/sync/SyncController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/sync/SyncController.kt
@@ -11,6 +11,8 @@ import io.lunarlogic.aircasting.bluetooth.BluetoothManager
 import io.lunarlogic.aircasting.events.AirBeamConnectionFailedEvent
 import io.lunarlogic.aircasting.events.sdcard.SDCardClearFinished
 import io.lunarlogic.aircasting.events.sdcard.SDCardSyncErrorEvent
+import io.lunarlogic.aircasting.events.sessions_sync.SessionsSyncErrorEvent
+import io.lunarlogic.aircasting.events.sessions_sync.SessionsSyncSuccessEvent
 import io.lunarlogic.aircasting.exceptions.ErrorHandler
 import io.lunarlogic.aircasting.lib.*
 import io.lunarlogic.aircasting.location.LocationHelper
@@ -79,15 +81,17 @@ class SyncController(
     }
 
     private fun refreshSessionList() {
-        mSessionsSyncService?.sync(
-            onSuccessCallback = {
-                mWizardNavigator.goToRefreshingSessionsSuccess(this)
-            },
-            onErrorCallack = {
-                mWizardNavigator.goToRefreshingSessionsError(this)
-            },
-            shouldDisplayErrors = false
-        )
+        mSessionsSyncService.sync(shouldDisplayErrors = false)
+    }
+
+    @Subscribe
+    fun onMessageEvent(event: SessionsSyncSuccessEvent) {
+        mWizardNavigator.goToRefreshingSessionsSuccess(this)
+    }
+
+    @Subscribe
+    fun onMessageEvent(event: SessionsSyncErrorEvent) {
+        mWizardNavigator.goToRefreshingSessionsError(this)
     }
 
     override fun refreshedSessionsContinueClicked() {

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
@@ -3,11 +3,14 @@ package io.lunarlogic.aircasting.sensor.airbeam3.sync
 import android.util.Log
 import io.lunarlogic.aircasting.events.sdcard.SDCardLinesReadEvent
 import io.lunarlogic.aircasting.events.sdcard.SDCardSyncErrorEvent
+import io.lunarlogic.aircasting.events.sessions_sync.SessionsSyncErrorEvent
+import io.lunarlogic.aircasting.events.sessions_sync.SessionsSyncSuccessEvent
 import io.lunarlogic.aircasting.exceptions.*
 import io.lunarlogic.aircasting.networking.services.SessionsSyncService
 import io.lunarlogic.aircasting.screens.new_session.select_device.DeviceItem
 import io.lunarlogic.aircasting.sensor.AirBeamConnector
 import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
 
 class SDCardSyncService(
     private val mSDCardDownloadService: SDCardDownloadService,
@@ -18,6 +21,9 @@ class SDCardSyncService(
     private val mErrorHandler: ErrorHandler
 ) {
     private val TAG = "SDCardSyncService"
+
+    private var mAirBeamConnector: AirBeamConnector? = null
+    private var mDeviceItem: DeviceItem? = null
 
     /*
 
@@ -35,6 +41,9 @@ class SDCardSyncService(
     fun run(airBeamConnector: AirBeamConnector, deviceItem: DeviceItem) {
         Log.d(TAG, "Downloading measurements from SD card")
 
+        mAirBeamConnector = airBeamConnector
+        mDeviceItem = deviceItem
+
         airBeamConnector.triggerSDCardDownload()
 
         mSDCardDownloadService.run(
@@ -42,19 +51,22 @@ class SDCardSyncService(
                 val event = SDCardLinesReadEvent(step, linesCount)
                 EventBus.getDefault().post(event)
             },
-            onDownloadFinished = { steps -> checkDownloadedFiles(airBeamConnector, deviceItem, steps) }
+            onDownloadFinished = { steps -> checkDownloadedFiles(steps) }
         )
     }
 
-    private fun checkDownloadedFiles(airBeamConnector: AirBeamConnector, deviceItem: DeviceItem, steps: List<SDCardReader.Step>) {
+    private fun checkDownloadedFiles(steps: List<SDCardReader.Step>) {
+        val airBeamConnector = mAirBeamConnector ?: return
+
         Log.d(TAG, "Checking downloaded files")
 
         if (mSDCardCSVFileChecker.run(steps)) {
             clearSDCard(airBeamConnector)
-            saveMobileMeasurementsLocally(airBeamConnector, deviceItem)
+            saveMobileMeasurementsLocally()
         } else {
             // fatal error, we can't proceed with sync
             handleError(SDCardDownloadedFileCorrupted())
+            cleanup()
         }
     }
 
@@ -62,42 +74,52 @@ class SDCardSyncService(
         EventBus.getDefault().post(SDCardSyncErrorEvent(exception))
     }
 
-    private fun saveMobileMeasurementsLocally(airBeamConnector: AirBeamConnector, deviceItem: DeviceItem) {
+    private fun saveMobileMeasurementsLocally() {
+        val deviceItem = mDeviceItem ?: return
+
         Log.d(TAG, "Processing mobile sessions")
 
         mSDCardMobileSessionsProcessor.run(deviceItem.id,
             onFinishCallback = {
-                sendMobileMeasurementsToBackend(airBeamConnector, deviceItem)
+                sendMobileMeasurementsToBackend()
             }
         )
     }
 
-    private fun sendMobileMeasurementsToBackend(airBeamConnector: AirBeamConnector, deviceItem: DeviceItem) {
+    private fun sendMobileMeasurementsToBackend() {
         val sessionsSyncService = mSessionsSyncService
 
         if (sessionsSyncService == null) {
             val cause = SDCardMissingSessionsSyncServiceError()
             mErrorHandler.handleAndDisplay(SDCardSessionsFinalSyncError(cause))
+            cleanup()
             return
         }
 
         Log.d(TAG, "Sending mobile sessions to backend")
-        sessionsSyncService.sync(
-            onSuccessCallback = {
-                sendFixedMeasurementsToBackend(airBeamConnector, deviceItem)
-            },
-            onErrorCallack = {
-                mErrorHandler.handleAndDisplay(SDCardSessionsFinalSyncError())
-            }
-        )
+        sessionsSyncService.sync()
     }
 
-    private fun sendFixedMeasurementsToBackend(airBeamConnector: AirBeamConnector, deviceItem: DeviceItem) {
+    @Subscribe
+    fun onMessageEvent(event: SessionsSyncSuccessEvent) {
+        sendFixedMeasurementsToBackend()
+    }
+
+    @Subscribe
+    fun onMessageEvent(event: SessionsSyncErrorEvent) {
+        mErrorHandler.handleAndDisplay(SDCardSessionsFinalSyncError())
+        cleanup()
+    }
+
+    private fun sendFixedMeasurementsToBackend() {
+        val deviceItem = mDeviceItem ?: return
+
         val uploadFixedMeasurementsService = mSDCardUploadFixedMeasurementsService
 
         if (uploadFixedMeasurementsService == null) {
             val cause = SDCardMissingSDCardUploadFixedMeasurementsServiceError()
             mErrorHandler.handleAndDisplay(SDCardSessionsFinalSyncError(cause))
+            cleanup()
             return
         }
 
@@ -114,6 +136,12 @@ class SDCardSyncService(
 
     private fun finish() {
         mSDCardDownloadService.deleteFiles()
+        cleanup()
         Log.d(TAG, "Sync finished")
+    }
+
+    private fun cleanup() {
+        mDeviceItem = null
+        mAirBeamConnector = null
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
@@ -6,6 +6,7 @@ import io.lunarlogic.aircasting.events.sdcard.SDCardSyncErrorEvent
 import io.lunarlogic.aircasting.events.sessions_sync.SessionsSyncErrorEvent
 import io.lunarlogic.aircasting.events.sessions_sync.SessionsSyncSuccessEvent
 import io.lunarlogic.aircasting.exceptions.*
+import io.lunarlogic.aircasting.lib.safeRegister
 import io.lunarlogic.aircasting.networking.services.SessionsSyncService
 import io.lunarlogic.aircasting.screens.new_session.select_device.DeviceItem
 import io.lunarlogic.aircasting.sensor.AirBeamConnector
@@ -41,6 +42,7 @@ class SDCardSyncService(
     fun run(airBeamConnector: AirBeamConnector, deviceItem: DeviceItem) {
         Log.d(TAG, "Downloading measurements from SD card")
 
+        EventBus.getDefault().safeRegister(this)
         mAirBeamConnector = airBeamConnector
         mDeviceItem = deviceItem
 
@@ -141,6 +143,7 @@ class SDCardSyncService(
     }
 
     private fun cleanup() {
+        EventBus.getDefault().unregister(this)
         mDeviceItem = null
         mAirBeamConnector = null
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -277,7 +277,7 @@
 
     <!-- Sync -->
     <string name="refreshing_sessions_header">Updating sessions</string>
-    <string name="refreshing_sessions_description">Sessions must be updated prior to syncing SD card.\nMake sure your device is connected to the Internet.</string>
+    <string name="refreshing_sessions_description">Sessions must be updated prior to syncing SD card. Make sure your device is connected to the Internet.</string>
     <string name="refreshed_sessions_header_successful">Success</string>
     <string name="refreshed_sessions_description_successful">Sessions were updated successfully.</string>
     <string name="refreshed_sessions_header_error">Something went wrong</string>


### PR DESCRIPTION
[Trello Task](https://trello.com/c/YWSb5xX3/1184-sd-card-sync-hangs-on-updating-sessions)
Fixed handling on success and on error for session sync service.
Callbacks are not working if there was ongoing sync triggered already.