### PR TITLE
Stream tap behavior

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -48,6 +48,8 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
     private var mLoader: ImageView?
 
     protected var mSessionPresenter: SessionPresenter? = null
+    protected var expandCardCallback: (() -> Unit?)? = null
+    protected var onExpandSessionCardClickedCallback: (() -> Unit?)? = null
 
     constructor(
         inflater: LayoutInflater,
@@ -65,6 +67,9 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         mNameTextView = findViewById(R.id.session_name)
         mInfoTextView = findViewById(R.id.session_info)
         mMeasurementsDescription = findViewById(R.id.session_measurements_description)
+
+        expandCardCallback = { expandSessionCard() }
+        onExpandSessionCardClickedCallback = { onExpandSessionCardClicked() }
 
         mMeasurementsTableContainer = MeasurementsTableContainer(
             context,
@@ -147,6 +152,12 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         bindChartData()
         bindFollowButtons(sessionPresenter)
         bindMapButton(sessionPresenter)
+        bindMeasurementsSelectable(mMeasurementsTableContainer, onExpandSessionCardClickedCallback, expandCardCallback)
+    }
+
+    protected open fun bindMeasurementsSelectable(mMeasurementsTableContainer: MeasurementsTableContainer, onExpandSessionCardClickedCallback: (() -> Unit?)?, expandCardCallback: (() -> Unit?)?) {
+        mMeasurementsTableContainer.makeSelectable(showMeasurementsTableValues())
+        mMeasurementsTableContainer.bindExpandCardCallbacks(expandCardCallback, onExpandSessionCardClickedCallback)
     }
 
     private fun bindLoader(sessionPresenter: SessionPresenter) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -243,8 +243,8 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
         setExpandCollapseButton()
         mExpandedSessionView.visibility = View.GONE
 
-        mMeasurementsTableContainer.makeStatic(showMeasurementsTableValues())
         bindCollapsedMeasurementsDesctription()
+        mMeasurementsTableContainer.makeCollapsed(showMeasurementsTableValues())
 
         adjustSessionCardPadding()
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveSessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveSessionViewMvcImpl.kt
@@ -33,6 +33,8 @@ class MobileActiveSessionViewMvcImpl : SessionViewMvcImpl<MobileActiveSessionVie
         return true
     }
 
+    override fun showExpandedMeasurementsTableValues() = true
+
     override fun bindCollapsedMeasurementsDesctription() {
         mMeasurementsDescription?.text = context.getString(R.string.session_last_sec_measurements_description)
     }
@@ -40,8 +42,6 @@ class MobileActiveSessionViewMvcImpl : SessionViewMvcImpl<MobileActiveSessionVie
     override fun bindExpandedMeasurementsDesctription() {
         mMeasurementsDescription?.text = context.getString(R.string.session_last_sec_measurements_description)
     }
-
-    override fun showExpandedMeasurementsTableValues() = true
 
     override fun buildBottomSheet(sessionPresenter: SessionPresenter?): BottomSheet? {
         return ActiveSessionActionsBottomSheet(this, sessionPresenter, mSupportFragmentManager)

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/fixed/FixedSessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/fixed/FixedSessionViewMvcImpl.kt
@@ -33,7 +33,7 @@ class FixedSessionViewMvcImpl(
     }
 
     override fun bindExpandedMeasurementsDesctription() {
-        mMeasurementsDescription?.text = context.getString(R.string.parameters)
+        mMeasurementsDescription?.text = context.getString(R.string.session_last_min_measurements_description)
     }
 
     override fun buildBottomSheet(sessionPresenter: SessionPresenter?): BottomSheet {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/fixed/FixedSessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/fixed/FixedSessionViewMvcImpl.kt
@@ -26,7 +26,7 @@ class FixedSessionViewMvcImpl(
         return false
     }
 
-    override fun showExpandedMeasurementsTableValues() = false
+    override fun showExpandedMeasurementsTableValues() = true
 
     override fun bindCollapsedMeasurementsDesctription() {
         mMeasurementsDescription?.text = context.getString(R.string.parameters)

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -69,16 +69,6 @@ class MeasurementsTableContainer {
         refresh()
     }
 
-    fun makeStatic(displayValues: Boolean = true) {
-        resetMeasurementsView()
-
-        mSelectable = false
-        mDisplayValues = displayValues
-        if (!displayValues) mMeasurementValues = null
-
-        refresh()
-    }
-
     fun makeCollapsed(displayValues: Boolean = true) {
         resetMeasurementsView()
         mSelectable = true

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -36,6 +36,8 @@ class MeasurementsTableContainer {
 
     private var mSessionPresenter: SessionPresenter? = null
     private var mOnMeasurementStreamChanged: ((MeasurementStream) -> Unit)? = null
+    private var expandCard: (() -> Unit?)? = null
+    private var onExpandSessionCard: (() -> Unit?)? = null
 
     constructor(
         context: Context,
@@ -106,6 +108,11 @@ class MeasurementsTableContainer {
         }
     }
 
+    fun bindExpandCardCallbacks(expandCardCallback: (() -> Unit?)?, onExpandSessionCardClickedCallback: (() -> Unit?)?) {
+        expandCard = expandCardCallback
+        onExpandSessionCard = onExpandSessionCardClickedCallback
+    }
+
     private fun resetMeasurementsView() {
         mMeasurementsTable?.isStretchAllColumns = false
         mMeasurementHeaders?.removeAllViews()
@@ -164,6 +171,8 @@ class MeasurementsTableContainer {
     }
 
     private fun markMeasurementHeaderAsSelected(stream: MeasurementStream) {
+        onExpandSessionCard?.invoke()
+        expandCard?.invoke()
         val index = mMeasurementStreams.indexOf(stream)
         try {
             val headerView = mMeasurementHeaders?.get(index)

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -77,6 +77,15 @@ class MeasurementsTableContainer {
         refresh()
     }
 
+    fun makeCollapsed(displayValues: Boolean = true) {
+        resetMeasurementsView()
+        mSelectable = true
+        mDisplayValues = displayValues
+        if (!displayValues) mMeasurementValues = null
+
+        refresh()
+    }
+
     fun refresh() {
         bindSession(mSessionPresenter, mOnMeasurementStreamChanged)
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/MeasurementsTableContainer.kt
@@ -64,7 +64,7 @@ class MeasurementsTableContainer {
     fun makeSelectable(displayValues: Boolean = true) {
         mSelectable = true
         mDisplayValues = displayValues
-        mMeasurementValues = mRootView?.measurement_values
+        if (displayValues) mMeasurementValues = mRootView?.measurement_values
 
         refresh()
     }


### PR DESCRIPTION
Important changes:
- I've removed `makeStatic` function in `MeasurementsTableContainer` and I've replaced it with `makeCollapsed` function in order to get selectable headers on tap
- I've added expand methods callbacks to table

<img width="293" alt="Screenshot 2021-03-19 at 14 28 47" src="https://user-images.githubusercontent.com/23139274/111787717-90899980-88bf-11eb-9c74-9446eb1c5fef.png">

AC:

- [x] Following: on parameter tap, indicate stream selection via bold text, colored oval
- [x] Following: on parameter tap, show chart for selected stream
- [x] Following: on parameter tap, show "unfollow", "map" (for outdoor sessions), and "graph" buttons
- [x] Mobile active: on parameter tap, indicate stream selection via bold text, colored oval
- [x] Mobile active: on parameter tap, show chart for selected stream
- [x] Mobile active: on parameter tap, show "map" & "graph" buttons
- [x] Mobile dormant: on parameter tap, indicate selection via bold text, colored oval
- [x] Mobile dormant: on parameter tap, show "map", "graph" buttons
- [x] Fixed: on parameter tap, indicate stream selection via bold text, colored oval
- [x] Fixed: on parameter tap, show "follow", "map" (for outdoor sessions), and "graph" buttons
- [x] Fixed: on parameter tap, change card text from "Parameters" to "Last minute measurement" 
- [x] Change arrow behavior on expand by tapping
- [x] Mobile dormat: hide measurements on collapsed card
- [x] Fixed: hide measurements on collapsed card
