### PR TITLE
Check if map and graph buttons clickable area can be expanded a bit more

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionViewMvcImpl.kt
@@ -341,7 +341,7 @@ abstract class SessionViewMvcImpl<ListenerType>: BaseObservableViewMvc<ListenerT
 
     private fun getExpandedTouchDelegate(child: View) : TouchDelegate {
         val paddingX = 10
-        val paddingY = 40
+        val paddingY = 100
         var rect = Rect()
         child.getHitRect(rect)
         rect.left -= paddingX

--- a/app/src/main/res/layout/expanded_session_view.xml
+++ b/app/src/main/res/layout/expanded_session_view.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:paddingTop="@dimen/keyline_4"
     android:paddingBottom="@dimen/keyline_4">
 
     <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
https://trello.com/b/UPSdV5fV/aircasting-android

We've already used touch delegate in SessionViewMvcImpl so there is not much more to be done.
The reason increasing "paddingY" in "getExpandedTouchDelegate" does not work is that area of expanded_session_view is limited. To increase clickable area of map and graph buttons we also need to increase padding of those buttons from the top of their parent view- expanded_session_view. We need to remember that by increasing the expanded_session_view layout we increase the session_card layout which probably might be important as we want to keep the card readable on smaller screens (??).
Anyways,  if we decide for this solution we will have to adjust dp values on layouts that I provided temporary during testing.
