### PR TITLE
mobile active > map & graph: when loading long sessions, the spinner is missing

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/models/MeasurementStream.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/models/MeasurementStream.kt
@@ -163,7 +163,7 @@ class MeasurementStream(
         val measurementsSize = allMeasurements.size
 
         if (amount >= measurementsSize) return allMeasurements
-        
+
         return allMeasurements.subList(measurementsSize - amount, measurementsSize)
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -92,13 +92,15 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
         mSessionPresenter = sessionPresenter
 
         bindSessionDetails()
-        if (sessionPresenter?.selectedStream != null) showSlider()
+        if (sessionPresenter?.selectedStream != null  && sessionPresenter.session == null) showSlider()
 
         mMeasurementsTableContainer.bindSession(mSessionPresenter, this::onMeasurementStreamChanged)
         bindStatisticsContainer()
         mHLUSlider.bindSensorThreshold(sessionPresenter?.selectedSensorThreshold())
 
-        mSessionMeasurementsDescription?.visibility = View.VISIBLE
+        if (mSessionPresenter?.session != null) {
+            mSessionMeasurementsDescription?.visibility = View.VISIBLE
+        }
     }
 
     private fun showSlider() {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -91,7 +91,7 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
     override fun bindSession(sessionPresenter: SessionPresenter?) {
         mSessionPresenter = sessionPresenter
 
-        if (sessionPresenter?.selectedStream?.measurements?.isNotEmpty() == true) {
+        if (sessionPresenter?.selectedStream?.measurements?.isNotEmpty() == true) { //TODO: check if works fine after Marysia's changes with memory leaks!
             bindSessionDetails()
             showSlider()
             mMeasurementsTableContainer.bindSession(mSessionPresenter, this::onMeasurementStreamChanged)

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -91,19 +91,13 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
     override fun bindSession(sessionPresenter: SessionPresenter?) {
         mSessionPresenter = sessionPresenter
 
-        if (sessionPresenter?.selectedStream != null && sessionPresenter.selectedStream?.measurements?.isNotEmpty() == true) {
+        if (sessionPresenter?.selectedStream?.measurements?.isNotEmpty() == true) {
             bindSessionDetails()
             showSlider()
-        }
-
-        if (sessionPresenter?.selectedStream?.measurements?.isNotEmpty() == true){
             mMeasurementsTableContainer.bindSession(mSessionPresenter, this::onMeasurementStreamChanged)
             bindStatisticsContainer()
-        }
 
-        mHLUSlider.bindSensorThreshold(sessionPresenter?.selectedSensorThreshold())
-
-        if (sessionPresenter?.selectedStream?.measurements?.isNotEmpty() == true) {
+            mHLUSlider.bindSensorThreshold(sessionPresenter?.selectedSensorThreshold())
             mSessionMeasurementsDescription?.visibility = View.VISIBLE
         }
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -91,14 +91,19 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
     override fun bindSession(sessionPresenter: SessionPresenter?) {
         mSessionPresenter = sessionPresenter
 
-        bindSessionDetails()
-        if (sessionPresenter?.selectedStream != null  && sessionPresenter.session == null) showSlider()
+        if (sessionPresenter?.selectedStream != null && sessionPresenter.selectedStream?.measurements?.isNotEmpty() == true) {
+            bindSessionDetails()
+            showSlider()
+        }
 
-        mMeasurementsTableContainer.bindSession(mSessionPresenter, this::onMeasurementStreamChanged)
-        bindStatisticsContainer()
+        if (sessionPresenter?.selectedStream?.measurements?.isNotEmpty() == true){
+            mMeasurementsTableContainer.bindSession(mSessionPresenter, this::onMeasurementStreamChanged)
+            bindStatisticsContainer()
+        }
+
         mHLUSlider.bindSensorThreshold(sessionPresenter?.selectedSensorThreshold())
 
-        if (mSessionPresenter?.session != null) {
+        if (sessionPresenter?.selectedStream?.measurements?.isNotEmpty() == true) {
             mSessionMeasurementsDescription?.visibility = View.VISIBLE
         }
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/StatisticsContainer.kt
@@ -53,7 +53,9 @@ class StatisticsContainer {
         mSensorThreshold = sessionPresenter?.selectedSensorThreshold()
         mVisibleTimeSpan = sessionPresenter?.visibleTimeSpan
 
-        mStatisticsView?.visibility = View.VISIBLE
+        if (stream != null) {
+            mStatisticsView?.visibility = View.VISIBLE
+        }
 
         bindLastMeasurement(sessionPresenter)
         bindAvgStatistics(stream)

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
@@ -71,10 +71,7 @@ class GraphContainer: OnChartGestureListener {
         mMeasurementsSample = mGetMeasurementsSample.invoke()
 
         drawSession()
-        if (mMeasurementsSample.isNotEmpty()) {
-            showGraph()
-        }
-
+        if (mMeasurementsSample.isNotEmpty()) showGraph()
     }
 
     fun refresh(sessionPresenter: SessionPresenter?) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
@@ -71,7 +71,10 @@ class GraphContainer: OnChartGestureListener {
         mMeasurementsSample = mGetMeasurementsSample.invoke()
 
         drawSession()
-        showGraph()
+        if (mMeasurementsSample.isNotEmpty()) {
+            showGraph()
+        }
+
     }
 
     fun refresh(sessionPresenter: SessionPresenter?) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphViewMvcImpl.kt
@@ -52,7 +52,7 @@ abstract class GraphViewMvcImpl: SessionDetailsViewMvcImpl {
     override fun bindSession(sessionPresenter: SessionPresenter?) {
         super.bindSession(sessionPresenter)
         graphContainer.bindSession(mSessionPresenter)
-        hideLoader(mLoader)
+        if (mSessionPresenter?.selectedStream?.measurements?.isNotEmpty() == true) hideLoader(mLoader)
     }
 
     override fun onMeasurementStreamChanged(measurementStream: MeasurementStream) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
@@ -91,9 +91,7 @@ class MapContainer: OnMapReadyCallback {
 
         drawSession()
         animateCameraToSession()
-        if (mMeasurements.isNotEmpty()) {
-            showMap()
-        }
+        if (mMeasurements.isNotEmpty()) showMap()
     }
 
     fun bindSession(sessionPresenter: SessionPresenter?) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
@@ -91,7 +91,9 @@ class MapContainer: OnMapReadyCallback {
 
         drawSession()
         animateCameraToSession()
-        showMap()
+        if (mMeasurements.isNotEmpty()) {
+            showMap()
+        }
     }
 
     fun bindSession(sessionPresenter: SessionPresenter?) {

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapViewMvcImpl.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapViewMvcImpl.kt
@@ -52,7 +52,7 @@ abstract class MapViewMvcImpl: SessionDetailsViewMvcImpl {
     override fun bindSession(sessionPresenter: SessionPresenter?) {
         super.bindSession(sessionPresenter)
         mMapContainer.bindSession(mSessionPresenter)
-        hideLoader(mLoader)
+        if (mSessionPresenter?.selectedStream?.measurements?.isNotEmpty() == true) hideLoader(mLoader)
     }
 
     override fun centerMap(location: Location) {


### PR DESCRIPTION
https://trello.com/b/UPSdV5fV/aircasting-android

Due to my research the bug happens when the map/graph are already loaded but the session is not downloaded yet. 
To this moment app was showing loader only during map loading without checking if the session is downloaded and possible to show. If the session wasn't downloaded the loader was hidden anyways and empty map appeared on screen.

I changed the condition so now app shows loader unless the list of measurement is not empty - it means the session is downloaded and ready to view.