### PR TITLE
Place user on active sessions tab if there are any active mobile sessions

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/sessions.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/sessions.kt
@@ -174,6 +174,9 @@ interface SessionDao {
     @Query("SELECT * FROM sessions WHERE uuid=:uuid AND deleted=0")
     fun loadSessionByUUID(uuid: String): SessionDBObject?
 
+    @Query("SELECT * FROM sessions WHERE status=:status AND type=:type AND deleted=0")
+    fun loadSessionByStatusAndType(status: Session.Status, type: Session.Type): SessionDBObject?
+
     @Query("SELECT * FROM sessions WHERE device_id=:deviceId AND status=:status AND type=:type AND deleted=0")
     fun loadSessionByDeviceIdStatusAndType(deviceId: String, status: Session.Status, type: Session.Type): SessionDBObject?
 

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/SessionsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/SessionsRepository.kt
@@ -76,6 +76,12 @@ class SessionsRepository {
         return mDatabase.sessions().loadSessionByStatusTypeAndDeviceType(Session.Status.RECORDING, Session.Type.MOBILE, DeviceItem.Type.MIC) != null
     }
 
+
+    fun mobileActiveSessionExists(): Boolean {
+        return mDatabase.sessions().loadSessionByStatusAndType(Session.Status.RECORDING, Session.Type.MOBILE) != null ||
+                mDatabase.sessions().loadSessionByStatusAndType(Session.Status.DISCONNECTED, Session.Type.MOBILE) != null
+    }
+
     fun disconnectMobileBluetoothSessions() {
         mDatabase.sessions().disconnectSessions(Session.Status.DISCONNECTED, DeviceItem.Type.MIC, Session.Type.MOBILE, Session.Status.RECORDING)
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/DashboardController.kt
@@ -1,12 +1,19 @@
 package io.lunarlogic.aircasting.screens.dashboard
 
+import io.lunarlogic.aircasting.database.DatabaseProvider
+import io.lunarlogic.aircasting.database.repositories.SessionsRepository
+import io.lunarlogic.aircasting.models.Session
 import io.lunarlogic.aircasting.screens.common.BaseController
 
 class DashboardController(
-    viewMvc: DashboardViewMvcImpl?
+    private val viewMvc: DashboardViewMvcImpl?
 ) : BaseController<DashboardViewMvcImpl>(viewMvc) {
+    private val mSessionRepository = SessionsRepository()
 
     fun onCreate(tabId: Int?) {
-        mViewMvc?.goToTab(tabId ?: 0)
+        DatabaseProvider.runQuery {
+            if (mSessionRepository.mobileActiveSessionExists()) viewMvc?.goToTab(DashboardPagerAdapter.tabIndexForSessionType(Session.Type.MOBILE, Session.Status.RECORDING))
+            else viewMvc?.goToTab(tabId ?: 0)
+        }
     }
 }


### PR DESCRIPTION
Last part of this task:
https://trello.com/c/SqeybHkP/1178-place-user-on-active-sessions-tab-if-there-are-any-active-mobile-sessions

Marysia suggested to add this check in MainController. Wasn't quite sure how to do it there- 
I added sessionsRepository field in dashboardController and use it to check if we got any existing mobile active session- if yes, then we go to Mobile Active tab instead of Following at the start.