### PR TITLE
mobile active > map: remove google maps icons from bottom right hand corner

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
@@ -339,6 +339,7 @@ class MapContainer: OnMapReadyCallback {
         mapOptions.useViewLifecycleInFragment(true)
         mapOptions.zoomControlsEnabled(false)
         mapOptions.zoomGesturesEnabled(true)
+        mapOptions.mapToolbarEnabled(false)
 
         return mapOptions
     }


### PR DESCRIPTION
https://trello.com/c/ZxCSfwlS/1216-mobile-active-map-remove-google-maps-icons-from-bottom-right-hand-corner