### PR TITLE
mobile active > notes: notes should always be on top of all other layers

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/map/MapContainer.kt
@@ -214,6 +214,7 @@ class MapContainer: OnMapReadyCallback {
         val marker = mMap?.addMarker(MarkerOptions()
             .position(LatLng(note.latitude, note.longitude))
             .icon(icon))
+        marker?.zIndex = Float.MAX_VALUE // We set Z-index so the note marker are first to be 'clicked' when user press map
         mMarkers?.set(marker?.id, note.number)
         mMap?.setOnMarkerClickListener { marker ->
             val noteNumber = mMarkers?.get(marker.id)


### PR DESCRIPTION
https://trello.com/c/V2DTxYNm/1219-mobile-active-notes-notes-should-always-be-on-top-of-all-other-layers