### PR TITLE
mobile active > graph: updating measurement list size in bindSession(after last measurement bug)

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
@@ -81,6 +81,7 @@ class GraphContainer: OnChartGestureListener {
         mSessionPresenter = sessionPresenter
         mMeasurementsSample = mGetMeasurementsSample.invoke()
         mNotes = mSessionPresenter?.session?.notes
+        if (mGraph?.isFullyZoomedOut == true) mVisibleEntriesNumber = mMeasurementsSample.size
 
         drawSession()
         if (mMeasurementsSample.isNotEmpty()) showGraph()

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphDataGenerator.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphDataGenerator.kt
@@ -20,7 +20,7 @@ class GraphDataGenerator(
     private var startTime = Date()
     private var hasNote = false
 
-    private val DEFAULT_LIMIT = 60
+    private val DEFAULT_LIMIT = 1000
 
     class Result(val entries: List<Entry>, val midnightPoints: List<Float>)
 

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphDataGenerator.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphDataGenerator.kt
@@ -20,7 +20,7 @@ class GraphDataGenerator(
     private var startTime = Date()
     private var hasNote = false
 
-    private val DEFAULT_LIMIT = 1000
+    private val DEFAULT_LIMIT = 60
 
     class Result(val entries: List<Entry>, val midnightPoints: List<Float>)
 


### PR DESCRIPTION
https://trello.com/c/hGEQt9Wq/1225-mobile-active-graph-avg-doesnt-update-until-graph-is-tapped

I believe that the bug occurred because of lack of line updating value of "visible entries" field in the "bindSession" function.
I wanted to include it when fixing "last measurement bug" but putting it there without any condition makes the graph unusable. We have to check if the graph is zoomed out and, if so update the 'visible entries' field with new size of MeasurementSample list (we bind session when we add new measurement to the list).