### PR TITLE
Share link - available immadietaly after finishing session

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/sessions.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/sessions.kt
@@ -188,14 +188,17 @@ interface SessionDao {
     @Query("SELECT * FROM sessions WHERE status=:status AND type=:type AND device_type=:deviceType AND deleted=0")
     fun loadSessionByStatusTypeAndDeviceType(status: Session.Status, type: Session.Type, deviceType: DeviceItem.Type): SessionDBObject?
 
-    @Query("UPDATE sessions SET name=:name, tags=:tags, end_time=:endTime, status=:status WHERE uuid=:uuid")
-    fun update(uuid: String, name: String, tags: ArrayList<String>, endTime: Date, status: Session.Status)
+    @Query("UPDATE sessions SET name=:name, tags=:tags, end_time=:endTime, status=:status, version=:version, url_location=:urlLocation WHERE uuid=:uuid")
+    fun update(uuid: String, name: String, tags: ArrayList<String>, endTime: Date, status: Session.Status, version: Int, urlLocation: String?)
 
     @Query("UPDATE sessions SET followed_at=:followedAt WHERE uuid=:uuid")
     fun updateFollowedAt(uuid: String, followedAt: Date?)
 
     @Query("UPDATE sessions SET status=:status WHERE uuid=:uuid")
     fun updateStatus(uuid: String, status: Session.Status)
+
+    @Query("UPDATE sessions SET url_location=:urlLocation WHERE uuid=:uuid")
+    fun updateUrlLocation(uuid: String, urlLocation: String?)
 
     @Query("UPDATE sessions SET status=:newStatus WHERE device_id=:deviceId AND status=:existingStatus")
     fun disconnectSession(newStatus: Session.Status, deviceId: String, existingStatus: Session.Status)

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/SessionsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/SessionsRepository.kt
@@ -63,7 +63,7 @@ class SessionsRepository {
     fun update(session: Session) {
         session.endTime?.let {
             mDatabase.sessions().update(session.uuid, session.name, session.tags,
-                it, session.status)
+                it, session.status, session.version, session.urlLocation)
         }
     }
 
@@ -133,5 +133,9 @@ class SessionsRepository {
 
     fun updateSessionStatus(session: Session, status: Session.Status) {
         mDatabase.sessions().updateStatus(session.uuid, status)
+    }
+
+    fun updateUrlLocation(session: Session, urlLocation: String?) {
+        mDatabase.sessions().updateUrlLocation(session.uuid, urlLocation)
     }
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/MobileSessionUploadService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/MobileSessionUploadService.kt
@@ -12,7 +12,7 @@ import retrofit2.Callback
 import retrofit2.Response
 
 class MobileSessionUploadService(private val apiService: ApiService, private val errorHandler: ErrorHandler) {
-    fun upload(session: Session, successCallback: () -> Unit) {
+    fun upload(session: Session, successCallback: (response: Response<UploadSessionResponse>) -> Unit) {
         val sessionParams = SessionParams(session)
         val sessionBody = CreateSessionBody(
             GzippedParams.get(sessionParams, SessionParams::class.java)
@@ -21,7 +21,7 @@ class MobileSessionUploadService(private val apiService: ApiService, private val
         call.enqueue(object : Callback<UploadSessionResponse> {
             override fun onResponse(call: Call<UploadSessionResponse>, response: Response<UploadSessionResponse>) {
                 if (response.isSuccessful) {
-                    successCallback()
+                    successCallback(response)
                 } else {
                     errorHandler.handle(UnexpectedAPIError())
                 }

--- a/app/src/main/java/io/lunarlogic/aircasting/networking/services/SessionsSyncService.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/networking/services/SessionsSyncService.kt
@@ -16,6 +16,7 @@ import io.lunarlogic.aircasting.models.Session
 import io.lunarlogic.aircasting.networking.params.SyncSessionBody
 import io.lunarlogic.aircasting.networking.params.SyncSessionParams
 import io.lunarlogic.aircasting.networking.responses.SyncResponse
+import io.lunarlogic.aircasting.networking.responses.UploadSessionResponse
 import org.greenrobot.eventbus.EventBus
 import retrofit2.Call
 import retrofit2.Callback
@@ -145,7 +146,10 @@ class SessionsSyncService {
         uuids.forEach { uuid ->
             val session = sessionRepository.loadSessionForUpload(uuid)
             if (session != null && isUploadable(session)) {
-                val onUploadSuccess = {
+                val onUploadSuccess = { response: Response<UploadSessionResponse> ->
+                    DatabaseProvider.runQuery {
+                        sessionRepository.updateUrlLocation(session, response.body()?.location)
+                    }
                     // TODO: handle update notes - adding photoPath
                 }
                 uploadService.upload(session, onUploadSuccess)

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/SessionsController.kt
@@ -170,7 +170,14 @@ abstract class SessionsController(
     }
 
     override fun onShareSessionClicked(session: Session) {
-        startShareSessionBottomSheet(session)
+        var reloadedSession: Session? = null
+        DatabaseProvider.runQuery { scope ->
+            val dbSession = mSessionsViewModel.reloadSessionWithMeasurements(session.uuid)
+            dbSession?.let {
+                reloadedSession = Session(dbSession)
+                startShareSessionBottomSheet(reloadedSession ?: session)
+            }
+        }
     }
 
     override fun onDeleteSessionClicked(session: Session) {


### PR DESCRIPTION
There were few problems here:
- we were not updating urlSession on upload (not sure though how come we were ever updating it. Maybe when we logged out and logged in and fetching sessions freshly from API?)
- even if we were fetching url straight away, it would not be available immediately because we were not reloading session from DB before trying to share url (so we would use session from before uploading it to API, therefore without link)
- also, I noticed we were not updating session url and version when updating session on sync. Not sure if versioning is still actively used but in case it is, we should be compatible