### PR TITLE
Active sessions tab optimisation

### DIFF
--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/27.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/27.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 26,
+    "version": 27,
     "identityHash": "04a9e31bf5c80cb1f1783864cc6030e2",
     "entities": [
       {

--- a/app/src/main/java/io/lunarlogic/aircasting/database/DatabaseProvider.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/DatabaseProvider.kt
@@ -20,9 +20,10 @@ import kotlinx.coroutines.launch
         MeasurementStreamDBObject::class,
         MeasurementDBObject::class,
         SensorThresholdDBObject::class,
-        NoteDBObject::class
+        NoteDBObject::class,
+        ActiveSessionMeasurementDBObject::class
     ),
-    version = 26,
+    version = 27,
     exportSchema = true
 )
 @TypeConverters(
@@ -38,6 +39,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun measurements(): MeasurementDao
     abstract fun sensorThresholds(): SensorThresholdDao
     abstract fun notes(): NoteDao
+    abstract fun activeSessionsMeasurements(): ActiveSessionMeasurementDao
 }
 
 class DatabaseProvider {
@@ -66,7 +68,8 @@ class DatabaseProvider {
                     MIGRATION_22_23,
                     MIGRATION_23_24,
                     MIGRATION_24_25,
-                    MIGRATION_25_26
+                    MIGRATION_25_26,
+                    MIGRATION_26_27
                 ).build()
             }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/active_sessions_measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/active_sessions_measurements.kt
@@ -52,10 +52,10 @@ interface ActiveSessionMeasurementDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(measurement: ActiveSessionMeasurementDBObject): Long
 
-    @Query("UPDATE active_sessions_measurements SET value=:value, time=:time, latitude=:latitude, longitude=:longitude WHERE session_id=:sessionId AND stream_id=:streamId")
-    fun update(sessionId: Long, streamId: Long, value: Double, time: Date, latitude: Double?, longitude: Double?)
+    @Query("UPDATE active_sessions_measurements SET value=:value, time=:time, latitude=:latitude, longitude=:longitude WHERE id=:id")
+    fun update(id: Int, value: Double, time: Date, latitude: Double?, longitude: Double?)
 
-    @Query("DELETE FROM measurements WHERE id=:id")
+    @Query("DELETE FROM active_sessions_measurements WHERE id=:id")
     fun deleteActiveSessionMeasurement(id: Int)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/active_sessions_measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/active_sessions_measurements.kt
@@ -40,8 +40,6 @@ data class ActiveSessionMeasurementDBObject(
 
 @Dao
 interface ActiveSessionMeasurementDao {
-//    @Query("SELECT * FROM measurements")
-//    fun getAll(): List<MeasurementDBObject>
 
     @Query("SELECT count(id) FROM active_sessions_measurements WHERE session_id=:sessionId AND stream_id=:streamId")
     fun countBySessionAndStream(sessionId: Long, streamId: Long): Int
@@ -57,9 +55,6 @@ interface ActiveSessionMeasurementDao {
 
     @Query("DELETE FROM active_sessions_measurements WHERE id=:id")
     fun deleteActiveSessionMeasurement(id: Int)
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertAll(measurements: List<ActiveSessionMeasurementDBObject>): List<Long>
 
     @Transaction
     fun deleteAndInsertInTransaction(measurement: ActiveSessionMeasurementDBObject) {

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/active_sessions_measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/active_sessions_measurements.kt
@@ -56,6 +56,9 @@ interface ActiveSessionMeasurementDao {
     @Query("DELETE FROM active_sessions_measurements WHERE id=:id")
     fun deleteActiveSessionMeasurement(id: Int)
 
+    @Query("DELETE FROM active_sessions_measurements WHERE session_id=:sessionId")
+    fun deleteActiveSessionMeasurementsBySession(sessionId: Long)
+
     @Transaction
     fun deleteAndInsertInTransaction(measurement: ActiveSessionMeasurementDBObject) {
         val id = getOldestMeasurementId(measurement.sessionId, measurement.streamId)

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/active_sessions_measurements.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/active_sessions_measurements.kt
@@ -1,0 +1,70 @@
+package io.lunarlogic.aircasting.database.data_classes
+
+import androidx.lifecycle.LiveData
+import androidx.room.*
+import io.lunarlogic.aircasting.models.Session
+import java.util.*
+
+@Entity(
+    tableName = "active_sessions_measurements",
+    foreignKeys = [
+        ForeignKey(
+            entity = MeasurementStreamDBObject::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("stream_id"),
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = SessionDBObject::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("session_id"),
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index("stream_id"),
+        Index("session_id")
+    ]
+)
+data class ActiveSessionMeasurementDBObject(
+    @ColumnInfo(name = "stream_id") val streamId: Long,
+    @ColumnInfo(name = "session_id") val sessionId: Long,
+    @ColumnInfo(name = "value") val value: Double,
+    @ColumnInfo(name = "time") val time: Date,
+    @ColumnInfo(name = "latitude") val latitude: Double?,
+    @ColumnInfo(name = "longitude") val longitude: Double?
+) {
+    @PrimaryKey(autoGenerate = true)
+    var id: Long = 0
+}
+
+@Dao
+interface ActiveSessionMeasurementDao {
+//    @Query("SELECT * FROM measurements")
+//    fun getAll(): List<MeasurementDBObject>
+
+    @Query("SELECT count(id) FROM active_sessions_measurements WHERE session_id=:sessionId AND stream_id=:streamId")
+    fun countBySessionAndStream(sessionId: Long, streamId: Long): Int
+
+    @Query("SELECT id FROM active_sessions_measurements WHERE session_id=:sessionId AND stream_id=:streamId ORDER BY time ASC LIMIT 1")
+    fun getOldestMeasurementId(sessionId: Long, streamId: Long): Int
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insert(measurement: ActiveSessionMeasurementDBObject): Long
+
+    @Query("UPDATE active_sessions_measurements SET value=:value, time=:time, latitude=:latitude, longitude=:longitude WHERE session_id=:sessionId AND stream_id=:streamId")
+    fun update(sessionId: Long, streamId: Long, value: Double, time: Date, latitude: Double?, longitude: Double?)
+
+    @Query("DELETE FROM measurements WHERE id=:id")
+    fun deleteActiveSessionMeasurement(id: Int)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertAll(measurements: List<ActiveSessionMeasurementDBObject>): List<Long>
+
+    @Transaction
+    fun deleteAndInsertInTransaction(measurement: ActiveSessionMeasurementDBObject) {
+        val id = getOldestMeasurementId(measurement.sessionId, measurement.streamId)
+        deleteActiveSessionMeasurement(id)
+        insert(measurement)
+    }
+}

--- a/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/sessions.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/data_classes/sessions.kt
@@ -108,6 +108,18 @@ class StreamWithMeasurementsDBObject {
     lateinit var measurements: List<MeasurementDBObject>
 }
 
+class StreamWithLastMeasurementsDBObject {
+    @Embedded
+    lateinit var stream: MeasurementStreamDBObject
+
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "stream_id",
+        entity = ActiveSessionMeasurementDBObject::class
+    )
+    lateinit var measurements: List<ActiveSessionMeasurementDBObject>
+}
+
 class CompleteSessionDBObject {
     @Embedded
     lateinit var session: SessionDBObject
@@ -127,6 +139,19 @@ class CompleteSessionDBObject {
     lateinit var notes: MutableList<NoteDBObject>
 }
 
+class SessionWithStreamsAndLastMeasurementsDBObject {
+    @Embedded
+    lateinit var session: SessionDBObject
+
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "session_id",
+        entity = MeasurementStreamDBObject::class
+    )
+    lateinit var streams: List<StreamWithLastMeasurementsDBObject>
+}
+
+
 @Dao
 interface SessionDao {
     @Query("SELECT * FROM sessions")
@@ -137,6 +162,9 @@ interface SessionDao {
 
     @Query("SELECT * FROM sessions WHERE deleted=0 AND type=:type AND status IN (:statuses) ORDER BY start_time DESC")
     fun loadAllByTypeAndStatusWithMeasurements(type: Session.Type, statuses: List<Int>): LiveData<List<SessionWithStreamsAndMeasurementsDBObject>>
+
+    @Query("SELECT * FROM sessions WHERE deleted=0 AND type=:type AND status IN (:statuses) ORDER BY start_time DESC")
+    fun loadAllByTypeAndStatusWithLastMeasurements(type: Session.Type, statuses: List<Int>): LiveData<List<SessionWithStreamsAndLastMeasurementsDBObject>>
 
     @Query("SELECT * FROM sessions WHERE deleted=0 AND type=:type AND status IN (:statuses) ORDER BY start_time DESC")
     fun loadAllByTypeAndStatusForComplete(type: Session.Type, statuses: List<Int>): LiveData<List<CompleteSessionDBObject>>

--- a/app/src/main/java/io/lunarlogic/aircasting/database/migrations/migration_27.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/migrations/migration_27.kt
@@ -1,0 +1,23 @@
+package io.lunarlogic.aircasting.database.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_26_27 = object : Migration(26, 27) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("CREATE TABLE `active_sessions_measurements` (" +
+                "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                "`session_id` INTEGER NOT NULL, " +
+                "`stream_id` INTEGER NOT NULL, " +
+                "`value` REAL NOT NULL, " +
+                "`time` INTEGER NOT NULL, " +
+                "`latitude` REAL, " +
+                "`longitude` REAL, " +
+                "FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE " +
+                "FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE " +
+                ")"
+        )
+        database.execSQL("CREATE  INDEX `index_active_sessions_measurements_stream_id` ON `active_sessions_measurements` (`stream_id`)")
+        database.execSQL("CREATE  INDEX `index_active_sessions_measurements_sessions_id` ON `active_sessions_measurements` (`session_id`)")
+    }
+}

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
@@ -44,4 +44,10 @@ class ActiveSessionMeasurementsRepository {
         }
     }
 
+    fun deleteBySessionId(sessionId: Long?) {
+        sessionId?.let {
+            mDatabase.activeSessionsMeasurements().deleteActiveSessionMeasurementsBySession(sessionId)
+        }
+    }
+
 }

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
@@ -5,7 +5,8 @@ import io.lunarlogic.aircasting.database.data_classes.ActiveSessionMeasurementDB
 import io.lunarlogic.aircasting.models.Measurement
 import java.util.*
 
-class LastMeasurementsRepository {
+class ActiveSessionMeasurementsRepository {
+    private val ACTIVE_SESSIONS_MEASUREMENTS_MAX_NUMBER = 60 * 9 //we only need 9 mins of measurements. TODO: we should calculate that number based on time
     private val mDatabase = DatabaseProvider.get()
 
     fun insert(measurementStreamId: Long, sessionId: Long, measurement: Measurement): Long {
@@ -21,22 +22,14 @@ class LastMeasurementsRepository {
         return mDatabase.activeSessionsMeasurements().insert(activeSessionMeasurementDBObject)
     }
 
-    private fun getOldestMeasurementID(sessionId: Long, streamId: Long): Int {
-        return mDatabase.activeSessionsMeasurements().getOldestMeasurementId(sessionId, streamId)
-    }
-
-    private fun update(id: Int, measurement: Measurement) {
-        mDatabase.activeSessionsMeasurements().update(id, measurement.value, measurement.time, measurement.latitude, measurement.longitude)
-    }
-
-    fun deleteAndInsert(measurement: ActiveSessionMeasurementDBObject) {
+    private fun deleteAndInsert(measurement: ActiveSessionMeasurementDBObject) {
         mDatabase.activeSessionsMeasurements().deleteAndInsertInTransaction(measurement)
     }
 
     fun createOrReplace(sessionId: Long, streamId: Long, measurement: Measurement) {
         val lastMeasurementsCount = mDatabase.activeSessionsMeasurements().countBySessionAndStream(sessionId, streamId)
 
-        if (lastMeasurementsCount > 540 ) {
+        if (lastMeasurementsCount > ACTIVE_SESSIONS_MEASUREMENTS_MAX_NUMBER ) {
             val activeSessionMeasurementDBObject = ActiveSessionMeasurementDBObject(
                 streamId,
                 sessionId,

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/LastMeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/LastMeasurementsRepository.kt
@@ -25,6 +25,10 @@ class LastMeasurementsRepository {
         return mDatabase.activeSessionsMeasurements().getOldestMeasurementId(sessionId, streamId)
     }
 
+    private fun update(id: Int, measurement: Measurement) {
+        mDatabase.activeSessionsMeasurements().update(id, measurement.value, measurement.time, measurement.latitude, measurement.longitude)
+    }
+
     fun deleteAndInsert(measurement: ActiveSessionMeasurementDBObject) {
         mDatabase.activeSessionsMeasurements().deleteAndInsertInTransaction(measurement)
     }
@@ -32,7 +36,7 @@ class LastMeasurementsRepository {
     fun createOrReplace(sessionId: Long, streamId: Long, measurement: Measurement) {
         val lastMeasurementsCount = mDatabase.activeSessionsMeasurements().countBySessionAndStream(sessionId, streamId)
 
-        if (lastMeasurementsCount > 15 ) {
+        if (lastMeasurementsCount > 540 ) {
             val activeSessionMeasurementDBObject = ActiveSessionMeasurementDBObject(
                 streamId,
                 sessionId,
@@ -41,7 +45,6 @@ class LastMeasurementsRepository {
                 measurement.latitude,
                 measurement.longitude
             )
-
             deleteAndInsert(activeSessionMeasurementDBObject)
         } else {
             insert(streamId, sessionId, measurement)

--- a/app/src/main/java/io/lunarlogic/aircasting/database/repositories/LastMeasurementsRepository.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/database/repositories/LastMeasurementsRepository.kt
@@ -1,0 +1,51 @@
+package io.lunarlogic.aircasting.database.repositories
+
+import io.lunarlogic.aircasting.database.DatabaseProvider
+import io.lunarlogic.aircasting.database.data_classes.ActiveSessionMeasurementDBObject
+import io.lunarlogic.aircasting.models.Measurement
+import java.util.*
+
+class LastMeasurementsRepository {
+    private val mDatabase = DatabaseProvider.get()
+
+    fun insert(measurementStreamId: Long, sessionId: Long, measurement: Measurement): Long {
+        val activeSessionMeasurementDBObject = ActiveSessionMeasurementDBObject(
+            measurementStreamId,
+            sessionId,
+            measurement.value,
+            measurement.time,
+            measurement.latitude,
+            measurement.longitude
+        )
+
+        return mDatabase.activeSessionsMeasurements().insert(activeSessionMeasurementDBObject)
+    }
+
+    private fun getOldestMeasurementID(sessionId: Long, streamId: Long): Int {
+        return mDatabase.activeSessionsMeasurements().getOldestMeasurementId(sessionId, streamId)
+    }
+
+    fun deleteAndInsert(measurement: ActiveSessionMeasurementDBObject) {
+        mDatabase.activeSessionsMeasurements().deleteAndInsertInTransaction(measurement)
+    }
+
+    fun createOrReplace(sessionId: Long, streamId: Long, measurement: Measurement) {
+        val lastMeasurementsCount = mDatabase.activeSessionsMeasurements().countBySessionAndStream(sessionId, streamId)
+
+        if (lastMeasurementsCount > 15 ) {
+            val activeSessionMeasurementDBObject = ActiveSessionMeasurementDBObject(
+                streamId,
+                sessionId,
+                measurement.value,
+                measurement.time,
+                measurement.latitude,
+                measurement.longitude
+            )
+
+            deleteAndInsert(activeSessionMeasurementDBObject)
+        } else {
+            insert(streamId, sessionId, measurement)
+        }
+    }
+
+}

--- a/app/src/main/java/io/lunarlogic/aircasting/models/Measurement.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/models/Measurement.kt
@@ -1,5 +1,6 @@
 package io.lunarlogic.aircasting.models
 
+import io.lunarlogic.aircasting.database.data_classes.ActiveSessionMeasurementDBObject
 import io.lunarlogic.aircasting.database.data_classes.MeasurementDBObject
 import io.lunarlogic.aircasting.events.NewMeasurementEvent
 import io.lunarlogic.aircasting.lib.DateConverter
@@ -23,6 +24,13 @@ class Measurement(
         measurementDBObject.latitude,
         measurementDBObject.longitude,
         measurementDBObject.averaging_frequency
+    )
+
+    constructor(activeSessionMeasurementDBObject: ActiveSessionMeasurementDBObject): this(
+        activeSessionMeasurementDBObject.value,
+        activeSessionMeasurementDBObject.time,
+        activeSessionMeasurementDBObject.latitude,
+        activeSessionMeasurementDBObject.longitude
     )
 
     constructor(measurementResponse: MeasurementResponse): this(

--- a/app/src/main/java/io/lunarlogic/aircasting/models/MeasurementStream.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/models/MeasurementStream.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.google.android.libraries.maps.model.LatLng
 import com.google.common.collect.Lists
 import io.lunarlogic.aircasting.database.data_classes.MeasurementStreamDBObject
+import io.lunarlogic.aircasting.database.data_classes.StreamWithLastMeasurementsDBObject
 import io.lunarlogic.aircasting.database.data_classes.StreamWithMeasurementsDBObject
 import io.lunarlogic.aircasting.events.NewMeasurementEvent
 import io.lunarlogic.aircasting.networking.responses.SessionStreamResponse
@@ -60,6 +61,13 @@ class MeasurementStream(
     constructor(streamWithMeasurementsDBObject: StreamWithMeasurementsDBObject):
             this(streamWithMeasurementsDBObject.stream) {
         this.mMeasurements = streamWithMeasurementsDBObject.measurements.map { measurementDBObject ->
+            Measurement(measurementDBObject)
+        }
+    }
+
+    constructor(streamWithLastMeasurementsDBObject: StreamWithLastMeasurementsDBObject):
+            this(streamWithLastMeasurementsDBObject.stream) {
+        this.mMeasurements = streamWithLastMeasurementsDBObject.measurements.map { measurementDBObject ->
             Measurement(measurementDBObject)
         }
     }

--- a/app/src/main/java/io/lunarlogic/aircasting/models/Session.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/models/Session.kt
@@ -283,7 +283,7 @@ class Session(
                 session.status != status ||
                 session.endTime != endTime ||
                 session.notes.size != notes.size ||
-                session.lastMeasurement().time != lastMeasurement().time
+                (session.measurementsCount() > 0 && session.lastMeasurement().time != lastMeasurement().time)
     }
 
     fun streamsSortedByDetailedType(): List<MeasurementStream> {

--- a/app/src/main/java/io/lunarlogic/aircasting/models/Session.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/models/Session.kt
@@ -106,6 +106,13 @@ class Session(
         }
     }
 
+    constructor(sessionWithStreamsAndLastMeasurementsDBObject: SessionWithStreamsAndLastMeasurementsDBObject):
+            this(sessionWithStreamsAndLastMeasurementsDBObject.session) {
+        this.mStreams = sessionWithStreamsAndLastMeasurementsDBObject.streams.map { streamWithMeasurementsDBObject ->
+            MeasurementStream(streamWithMeasurementsDBObject)
+        }
+    }
+
     companion object {
         fun generateUUID(): String {
             return UUID.randomUUID().toString()
@@ -275,7 +282,8 @@ class Session(
                 session.measurementsCount() != measurementsCount() ||
                 session.status != status ||
                 session.endTime != endTime ||
-                session.notes.size != notes.size
+                session.notes.size != notes.size ||
+                session.lastMeasurement().time != lastMeasurement().time
     }
 
     fun streamsSortedByDetailedType(): List<MeasurementStream> {

--- a/app/src/main/java/io/lunarlogic/aircasting/models/SessionsViewModel.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/models/SessionsViewModel.kt
@@ -20,8 +20,8 @@ class SessionsViewModel(): ViewModel() {
         return mDatabase.sessions().loadFollowingWithMeasurements()
     }
 
-    fun loadMobileActiveSessionsWithMeasurements(): LiveData<List<SessionWithStreamsAndMeasurementsDBObject>> {
-        return mDatabase.sessions().loadAllByTypeAndStatusWithMeasurements(
+    fun loadMobileActiveSessionsWithMeasurements(): LiveData<List<SessionWithStreamsAndLastMeasurementsDBObject>> {
+        return mDatabase.sessions().loadAllByTypeAndStatusWithLastMeasurements(
             Session.Type.MOBILE, listOf(Session.Status.RECORDING.value, Session.Status.DISCONNECTED.value))
     }
 

--- a/app/src/main/java/io/lunarlogic/aircasting/models/observers/ActiveMobileSessionsObserver.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/models/observers/ActiveMobileSessionsObserver.kt
@@ -1,0 +1,18 @@
+package io.lunarlogic.aircasting.models.observers
+
+import androidx.lifecycle.LifecycleOwner
+import io.lunarlogic.aircasting.database.data_classes.SessionWithStreamsAndLastMeasurementsDBObject
+import io.lunarlogic.aircasting.models.Session
+import io.lunarlogic.aircasting.models.SessionsViewModel
+import io.lunarlogic.aircasting.screens.dashboard.SessionsViewMvc
+
+class ActiveMobileSessionsObserver(
+    mLifecycleOwner: LifecycleOwner,
+    mSessionsViewModel: SessionsViewModel,
+    mViewMvc: SessionsViewMvc?
+): SessionsObserver<SessionWithStreamsAndLastMeasurementsDBObject>(mLifecycleOwner, mSessionsViewModel, mViewMvc) {
+
+    override fun buildSession(dbSession: SessionWithStreamsAndLastMeasurementsDBObject): Session {
+        return Session(dbSession)
+    }
+}

--- a/app/src/main/java/io/lunarlogic/aircasting/models/observers/MobileActiveSessionsObserver.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/models/observers/MobileActiveSessionsObserver.kt
@@ -6,7 +6,7 @@ import io.lunarlogic.aircasting.models.Session
 import io.lunarlogic.aircasting.models.SessionsViewModel
 import io.lunarlogic.aircasting.screens.dashboard.SessionsViewMvc
 
-class ActiveMobileSessionsObserver(
+class MobileActiveSessionsObserver(
     mLifecycleOwner: LifecycleOwner,
     mSessionsViewModel: SessionsViewModel,
     mViewMvc: SessionsViewMvc?

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveController.kt
@@ -11,10 +11,9 @@ import io.lunarlogic.aircasting.lib.NavigationController
 import io.lunarlogic.aircasting.lib.Settings
 import io.lunarlogic.aircasting.lib.safeRegister
 import io.lunarlogic.aircasting.models.Note
-import io.lunarlogic.aircasting.models.observers.ActiveSessionsObserver
 import io.lunarlogic.aircasting.models.Session
 import io.lunarlogic.aircasting.models.SessionsViewModel
-import io.lunarlogic.aircasting.models.observers.ActiveMobileSessionsObserver
+import io.lunarlogic.aircasting.models.observers.MobileActiveSessionsObserver
 import io.lunarlogic.aircasting.networking.services.ApiServiceFactory
 import io.lunarlogic.aircasting.screens.dashboard.DashboardPagerAdapter
 import io.lunarlogic.aircasting.screens.dashboard.SessionsController
@@ -41,7 +40,7 @@ class MobileActiveController(
     SessionsViewMvc.Listener,
     AddNoteBottomSheet.Listener {
 
-    private var mSessionsObserver = ActiveMobileSessionsObserver(mLifecycleOwner, mSessionsViewModel, mViewMvc)
+    private var mSessionsObserver = MobileActiveSessionsObserver(mLifecycleOwner, mSessionsViewModel, mViewMvc)
 
     override fun registerSessionsObserver() {
         mSessionsObserver.observe(mSessionsViewModel.loadMobileActiveSessionsWithMeasurements())

--- a/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveController.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/dashboard/active/MobileActiveController.kt
@@ -14,6 +14,7 @@ import io.lunarlogic.aircasting.models.Note
 import io.lunarlogic.aircasting.models.observers.ActiveSessionsObserver
 import io.lunarlogic.aircasting.models.Session
 import io.lunarlogic.aircasting.models.SessionsViewModel
+import io.lunarlogic.aircasting.models.observers.ActiveMobileSessionsObserver
 import io.lunarlogic.aircasting.networking.services.ApiServiceFactory
 import io.lunarlogic.aircasting.screens.dashboard.DashboardPagerAdapter
 import io.lunarlogic.aircasting.screens.dashboard.SessionsController
@@ -40,7 +41,7 @@ class MobileActiveController(
     SessionsViewMvc.Listener,
     AddNoteBottomSheet.Listener {
 
-    private var mSessionsObserver = ActiveSessionsObserver(mLifecycleOwner, mSessionsViewModel, mViewMvc)
+    private var mSessionsObserver = ActiveMobileSessionsObserver(mLifecycleOwner, mSessionsViewModel, mViewMvc)
 
     override fun registerSessionsObserver() {
         mSessionsObserver.observe(mSessionsViewModel.loadMobileActiveSessionsWithMeasurements())

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/SessionManager.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/SessionManager.kt
@@ -218,6 +218,7 @@ class SessionManager(private val mContext: Context, private val apiService: ApiS
             session?.let {
                 it.stopRecording()
                 sessionsRespository.update(it)
+                activeSessionMeasurementsRepository.deleteBySessionId(sessionId)
                 sessionsSyncService.sync()
                 averagingBackgroundService?.stop()
                 averagingPreviousMeasurementsBackgroundService?.stop()

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/SessionManager.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/SessionManager.kt
@@ -36,7 +36,7 @@ class SessionManager(private val mContext: Context, private val apiService: ApiS
     private val sessionsRespository = SessionsRepository()
     private val measurementStreamsRepository = MeasurementStreamsRepository()
     private val measurementsRepository = MeasurementsRepository()
-    private val lastMeasurementsRepository = LastMeasurementsRepository()
+    private val activeSessionMeasurementsRepository = ActiveSessionMeasurementsRepository()
     private val noteRepository = NoteRepository()
     private var mCallback: (() -> Unit)? = null
 
@@ -171,7 +171,7 @@ class SessionManager(private val mContext: Context, private val apiService: ApiS
                     val measurementStreamId =
                         measurementStreamsRepository.getIdOrInsert(sessionId, measurementStream)
                     measurementsRepository.insert(measurementStreamId, sessionId, measurement)
-                    lastMeasurementsRepository.createOrReplace(sessionId, measurementStreamId, measurement)
+                    activeSessionMeasurementsRepository.createOrReplace(sessionId, measurementStreamId, measurement)
                 } catch( e: SQLiteConstraintException) {
                     errorHandler.handle(DBInsertException(e))
                 }

--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/SessionManager.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/SessionManager.kt
@@ -5,10 +5,7 @@ import android.database.sqlite.SQLiteConstraintException
 import android.widget.Toast
 import io.lunarlogic.aircasting.R
 import io.lunarlogic.aircasting.database.DatabaseProvider
-import io.lunarlogic.aircasting.database.repositories.MeasurementStreamsRepository
-import io.lunarlogic.aircasting.database.repositories.MeasurementsRepository
-import io.lunarlogic.aircasting.database.repositories.NoteRepository
-import io.lunarlogic.aircasting.database.repositories.SessionsRepository
+import io.lunarlogic.aircasting.database.repositories.*
 import io.lunarlogic.aircasting.events.*
 import io.lunarlogic.aircasting.exceptions.DBInsertException
 import io.lunarlogic.aircasting.exceptions.ErrorHandler
@@ -39,6 +36,7 @@ class SessionManager(private val mContext: Context, private val apiService: ApiS
     private val sessionsRespository = SessionsRepository()
     private val measurementStreamsRepository = MeasurementStreamsRepository()
     private val measurementsRepository = MeasurementsRepository()
+    private val lastMeasurementsRepository = LastMeasurementsRepository()
     private val noteRepository = NoteRepository()
     private var mCallback: (() -> Unit)? = null
 
@@ -173,7 +171,7 @@ class SessionManager(private val mContext: Context, private val apiService: ApiS
                     val measurementStreamId =
                         measurementStreamsRepository.getIdOrInsert(sessionId, measurementStream)
                     measurementsRepository.insert(measurementStreamId, sessionId, measurement)
-
+                    lastMeasurementsRepository.createOrReplace(sessionId, measurementStreamId, measurement)
                 } catch( e: SQLiteConstraintException) {
                     errorHandler.handle(DBInsertException(e))
                 }


### PR DESCRIPTION
After 1h+ recording of mobile session, the data on the tab (last second measurements, hours, chart) would not update or update very slowly. 
I created a separate DB table for storing last 9 mins of measurements and we use that table to refresh data on the active sessions tab view.