### PR TITLE
Fixing "zombie" sessions

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/sensor/AirBeamReconnector.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/sensor/AirBeamReconnector.kt
@@ -69,11 +69,17 @@ class AirBeamReconnector(
         updateSessionStatus(mSession, Session.Status.RECORDING)
 
         mFinallyCallback?.invoke()
+        unregisterFromEventBus()
     }
 
     @Subscribe
     fun onMessageEvent(event: AirBeamConnectionFailedEvent) {
         mErrorCallback?.invoke()
         mFinallyCallback?.invoke()
+        unregisterFromEventBus()
+    }
+
+    private fun unregisterFromEventBus() {
+        EventBus.getDefault().unregister(this);
     }
 }


### PR DESCRIPTION
https://trello.com/c/bvTy7qcB/1264-ab2-mobile-active-reconnect-finish-session-app-displays-an-inappropriate-toast-session-becomes-a-zombie

We were not unregistering from event bus after reconnection success/error so it was listening for events forever and casing all of the zombie effect