### PR TITLE
Graph does not show up on the older phone (Android 6.1)

### DIFF
--- a/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
+++ b/app/src/main/java/io/lunarlogic/aircasting/screens/session_view/graph/GraphContainer.kt
@@ -235,6 +235,7 @@ class GraphContainer: OnChartGestureListener {
         mGraph?.setDrawGridBackground(false)
         mGraph?.isDragDecelerationEnabled = false
         mGraph?.setMaxVisibleValueCount(100000) //todo: this allows us to display icon on graph, value may be changed if icons would not display during tests
+        if (android.os.Build.VERSION.SDK_INT < 24 ) mGraph?.setHardwareAccelerationEnabled(false)
 
         mGraph?.onChartGestureListener = this
     }


### PR DESCRIPTION
https://trello.com/c/BYBXMrdG/1095-graph-does-not-show-up-on-the-older-phone-android-61

My solution is based on this "issue thread" on GitHub:
https://github.com/PhilJay/MPAndroidChart/issues/4606