### PR TITLE
[Airbeam3] SD card sync fail

### DIFF
--- a/app/schemas/pl.llp.aircasting.database.AppDatabase/27.json
+++ b/app/schemas/pl.llp.aircasting.database.AppDatabase/27.json
@@ -1,0 +1,604 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 27,
+    "identityHash": "04a9e31bf5c80cb1f1783864cc6030e2",
+    "entities": [
+      {
+        "tableName": "sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uuid` TEXT NOT NULL, `type` INTEGER NOT NULL, `device_id` TEXT, `device_type` INTEGER, `name` TEXT NOT NULL, `tags` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER, `latitude` REAL, `longitude` REAL, `status` INTEGER NOT NULL, `version` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `followed_at` INTEGER, `contribute` INTEGER NOT NULL, `locationless` INTEGER NOT NULL, `url_location` TEXT, `is_indoor` INTEGER NOT NULL, `averaging_frequency` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deviceType",
+            "columnName": "device_type",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "end_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followed_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contribute",
+            "columnName": "contribute",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationless",
+            "columnName": "locationless",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "urlLocation",
+            "columnName": "url_location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "is_indoor",
+            "columnName": "is_indoor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "averaging_frequency",
+            "columnName": "averaging_frequency",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_sessions_device_id",
+            "unique": false,
+            "columnNames": [
+              "device_id"
+            ],
+            "createSql": "CREATE  INDEX `index_sessions_device_id` ON `${TABLE_NAME}` (`device_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "measurement_streams",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `session_id` INTEGER NOT NULL, `sensor_package_name` TEXT NOT NULL, `sensor_name` TEXT NOT NULL, `measurement_type` TEXT NOT NULL, `measurement_short_type` TEXT NOT NULL, `unit_name` TEXT NOT NULL, `unit_symbol` TEXT NOT NULL, `threshold_very_low` INTEGER NOT NULL, `threshold_low` INTEGER NOT NULL, `threshold_medium` INTEGER NOT NULL, `threshold_high` INTEGER NOT NULL, `threshold_very_high` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensorPackageName",
+            "columnName": "sensor_package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensorName",
+            "columnName": "sensor_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "measurementType",
+            "columnName": "measurement_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "measurementShortType",
+            "columnName": "measurement_short_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitName",
+            "columnName": "unit_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitSymbol",
+            "columnName": "unit_symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdVeryLow",
+            "columnName": "threshold_very_low",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdLow",
+            "columnName": "threshold_low",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdMedium",
+            "columnName": "threshold_medium",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdHigh",
+            "columnName": "threshold_high",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdVeryHigh",
+            "columnName": "threshold_very_high",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_measurement_streams_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "createSql": "CREATE  INDEX `index_measurement_streams_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "measurements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "measurementStreamId",
+            "columnName": "measurement_stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "averaging_frequency",
+            "columnName": "averaging_frequency",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_measurements_measurement_stream_id",
+            "unique": false,
+            "columnNames": [
+              "measurement_stream_id"
+            ],
+            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+          },
+          {
+            "name": "index_measurements_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "createSql": "CREATE  INDEX `index_measurements_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "measurement_streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "measurement_stream_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sensor_thresholds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sensor_name` TEXT NOT NULL, `threshold_very_low` INTEGER NOT NULL, `threshold_low` INTEGER NOT NULL, `threshold_medium` INTEGER NOT NULL, `threshold_high` INTEGER NOT NULL, `threshold_very_high` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensorName",
+            "columnName": "sensor_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdVeryLow",
+            "columnName": "threshold_very_low",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdLow",
+            "columnName": "threshold_low",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdMedium",
+            "columnName": "threshold_medium",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdHigh",
+            "columnName": "threshold_high",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdVeryHigh",
+            "columnName": "threshold_very_high",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_sensor_thresholds_sensor_name",
+            "unique": false,
+            "columnNames": [
+              "sensor_name"
+            ],
+            "createSql": "CREATE  INDEX `index_sensor_thresholds_sensor_name` ON `${TABLE_NAME}` (`sensor_name`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `session_id` INTEGER NOT NULL, `date` INTEGER NOT NULL, `text` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `number` INTEGER NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_notes_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "createSql": "CREATE  INDEX `index_notes_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "active_sessions_measurements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_active_sessions_measurements_stream_id",
+            "unique": false,
+            "columnNames": [
+              "stream_id"
+            ],
+            "createSql": "CREATE  INDEX `index_active_sessions_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
+          },
+          {
+            "name": "index_active_sessions_measurements_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "createSql": "CREATE  INDEX `index_active_sessions_measurements_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "measurement_streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"04a9e31bf5c80cb1f1783864cc6030e2\")"
+    ]
+  }
+}

--- a/app/src/main/java/pl/llp/aircasting/sensor/AirBeamConnector.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/AirBeamConnector.kt
@@ -69,7 +69,7 @@ abstract class AirBeamConnector {
         Timer().schedule(mTimerTask, CONNECTION_TIMEOUT)
     }
 
-    private fun disconnect() {
+    fun disconnect() {
         unregisterFromEventBus()
 
         if (!cancelStarted.get()) {

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardReader.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardReader.kt
@@ -33,7 +33,11 @@ class SDCardReader {
 
         try {
             val measurementsInStepCountString = valueString.split(":").lastOrNull()?.trim()
-            val measurementsInStepCount = measurementsInStepCountString?.toInt()
+            val measurementsInStepCount = if (measurementsInStepCountString?.contains("⸮") == true) {
+                0
+            } else {
+                measurementsInStepCountString?.toInt()
+            }
 
             if (stepType != null && measurementsInStepCount != null) {
                 EventBus.getDefault().post(

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardReader.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardReader.kt
@@ -34,11 +34,12 @@ class SDCardReader {
 
         try {
             val measurementsInStepCountString = valueString.split(":").lastOrNull()?.trim()
-            // if the line is counter and is not a number, set to 0
-            // if the line is not counter - ignore this is e.g. SD_SYNC_FINISH
-            val measurementsInStepCount = if (counterNotInitialized(valueString)) {
-                0
+
+            val measurementsInStepCount = if (isCounterStep(valueString)) {
+                // if the line is counter and is not a number, set to 0
+                measurementsInStepCountString?.toIntOrNull() ?: 0
             } else {
+                // if the line is not counter - it will throw a NumberFormatException
                 measurementsInStepCountString?.toInt()
             }
 
@@ -59,12 +60,11 @@ class SDCardReader {
         }
     }
 
-    private fun counterNotInitialized(metaDataString: String): Boolean {
-        val metaDataSplit = metaDataString.split(":")
-        val description = metaDataSplit.firstOrNull()?.trim()
-        val value = metaDataSplit.lastOrNull()?.trim()
+    private fun isCounterStep(metaDataString: String): Boolean {
+        val metaDataFields = metaDataString.split(":")
+        val description = metaDataFields.firstOrNull()?.trim()
 
-        return (description?.contains("Counter") == true && value?.isDigitsOnly() == false)
+        return description?.contains("Counter") == true
     }
 
     fun onMeasurementsDownloaded(data: ByteArray?) {

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardReader.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardReader.kt
@@ -1,5 +1,6 @@
 package pl.llp.aircasting.sensor.airbeam3.sync
 
+import androidx.core.text.isDigitsOnly
 import pl.llp.aircasting.events.sdcard.SDCardClearFinished
 import pl.llp.aircasting.events.sdcard.SDCardReadEvent
 import pl.llp.aircasting.events.sdcard.SDCardReadFinished
@@ -33,7 +34,9 @@ class SDCardReader {
 
         try {
             val measurementsInStepCountString = valueString.split(":").lastOrNull()?.trim()
-            val measurementsInStepCount = if (measurementsInStepCountString?.contains("⸮") == true) {
+            // if the line is counter and is not a number, set to 0
+            // if the line is not counter - ignore this is e.g. SD_SYNC_FINISH
+            val measurementsInStepCount = if (counterNotInitialized(valueString)) {
                 0
             } else {
                 measurementsInStepCountString?.toInt()
@@ -54,6 +57,14 @@ class SDCardReader {
         } else if (valueString == CLEAR_FINISHED) {
             EventBus.getDefault().post(SDCardClearFinished())
         }
+    }
+
+    private fun counterNotInitialized(metaDataString: String): Boolean {
+        val metaDataSplit = metaDataString.split(":")
+        val description = metaDataSplit.firstOrNull()?.trim()
+        val value = metaDataSplit.lastOrNull()?.trim()
+
+        return (description?.contains("Counter") == true && value?.isDigitsOnly() == false)
     }
 
     fun onMeasurementsDownloaded(data: ByteArray?) {

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardReader.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardReader.kt
@@ -1,6 +1,5 @@
 package pl.llp.aircasting.sensor.airbeam3.sync
 
-import androidx.core.text.isDigitsOnly
 import pl.llp.aircasting.events.sdcard.SDCardClearFinished
 import pl.llp.aircasting.events.sdcard.SDCardReadEvent
 import pl.llp.aircasting.events.sdcard.SDCardReadFinished

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
@@ -138,6 +138,9 @@ class SDCardSyncService(
 
     private fun finish() {
         mSDCardDownloadService.deleteFiles()
+        // should we also do it after crearing SD card??
+//        mAirBeamConnector?.onDisconnected(mDeviceItem?.id!!)
+//        mAirBeamConnector?.disconnect()
         cleanup()
         Log.d(TAG, "Sync finished")
     }


### PR DESCRIPTION
-when attempting to sync an AB3 SD card for the first time, the sync fails.

-Raymond writes "I believe the problem could be that the index counter does not have an initial value when it is read from the EEPROM since it is brand new. I did not foresee this problem because I had the initially had the initial value already inputted from testing and never had a brand new AB3. The developers at Lunar Logic can detect the sideway flipped question mark (which is also byte value 255) and can give it a green light instead of corruption to pass the SD data. Once the app is updated with this fix please let me know so I can test it with the Rev D board I have from Jaycon Systems."

https://trello.com/c/GKmmZa6V/1198-sd-card-sync-fail