### PR TITLE
App crashes when you enter a fixed session map when measurements don't exist/are not loaded

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/screens/session_view/map/MapContainer.kt
+++ b/app/src/main/java/pl/llp/aircasting/screens/session_view/map/MapContainer.kt
@@ -263,6 +263,7 @@ class MapContainer: OnMapReadyCallback {
     }
 
     private fun animateCameraToFixedSession() {
+        if (mMeasurements.isEmpty()) return
         val session = mSessionPresenter?.session
         val location = session?.location
 


### PR DESCRIPTION
https://trello.com/c/X93kubhv/1297-app-crashes-when-you-enter-a-fixed-session-map-when-measurements-dont-exist-are-not-loaded