### PR TITLE
mobile active > map > delete note: first created note disappears instead of the chosen one

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -178,10 +178,7 @@ abstract class SessionDetailsViewMvcImpl: BaseObservableViewMvc<SessionDetailsVi
     }
 
     protected open fun onNoteDeleted(note: Note) {
-        mSessionPresenter?.session?.notes?.remove(
-            mSessionPresenter?.session?.notes?.find { note -> // I use this strange syntax instead of just remove(), because remove(note) does not work for some reason
-                note.number == note.number
-        })
+        mSessionPresenter?.session?.notes?.remove(note)
     }
 
     override fun onSensorThresholdChangedFromDialog(sensorThreshold: SensorThreshold) {


### PR DESCRIPTION
https://trello.com/c/pWPXddfn/1302-mobile-active-map-delete-note-first-created-note-disappears-instead-of-the-chosen-one