### PR TITLE
2.0.15 > mobile active > dashboard > add note: first note text is repeated for every subsequent note

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/database/data_classes/sessions.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/data_classes/sessions.kt
@@ -169,6 +169,13 @@ class SessionWithStreamsAndLastMeasurementsDBObject {
         entity = MeasurementStreamDBObject::class
     )
     lateinit var streams: List<StreamWithLastMeasurementsDBObject>
+
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "session_id",
+        entity = NoteDBObject::class
+    )
+    lateinit var notes: MutableList<NoteDBObject>
 }
 
 

--- a/app/src/main/java/pl/llp/aircasting/models/Session.kt
+++ b/app/src/main/java/pl/llp/aircasting/models/Session.kt
@@ -120,6 +120,9 @@ class Session(
         this.mStreams = sessionWithStreamsAndLastMeasurementsDBObject.streams.map { streamWithMeasurementsDBObject ->
             MeasurementStream(streamWithMeasurementsDBObject)
         }
+        this.mNotes = sessionWithStreamsAndLastMeasurementsDBObject.notes.map { noteDBObject ->
+            Note(noteDBObject)
+        }.toMutableList()
     }
 
     companion object {


### PR DESCRIPTION
https://trello.com/c/OqWsqgw7/1328-2015-mobile-active-dashboard-add-note-first-note-text-is-repeated-for-every-subsequent-note