### PR TITLE
Cross-device reconnection

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/sensor/AirBeamService.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/AirBeamService.kt
@@ -80,7 +80,7 @@ abstract class AirBeamService: SensorService(),
                 val sessionDBObject = mSessionRepository.getSessionByUUID(sessionUUID)
                 sessionDBObject?.let { sessionDBObject ->
                     val session = Session(sessionDBObject)
-                    if (session.type == Session.Type.MOBILE) {
+                    if (session.type == Session.Type.MOBILE && session.deviceId == event.sessionDeviceId) {
                         airbeamReconnector.initReconnectionTries(session, event.device)
                     }
                 }


### PR DESCRIPTION
https://trello.com/c/XaHmw2XB/1370-ab3-mobile-active-when-disconnected-unintentionally-standalone-screen-isnt-displayed

Problem described by Michael:
"When recording mobile sessions with the Play Store version (2.0.28), I've encountered some issues that I believe are related to the BT auto-reconnect feature from a secondary Android device interfering with the BT connection between the primary Android device and primary AB3, which leads to a premature BT disconnection between the primary Android device and primary AB3. "