### PR TITLE
increased CONNECTION_TIMEOUT to 30seconds

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/sensor/AirBeamConnector.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/AirBeamConnector.kt
@@ -20,7 +20,7 @@ abstract class AirBeamConnector {
     }
 
     private var mListener: Listener? = null
-    private val CONNECTION_TIMEOUT = 20000L
+    private val CONNECTION_TIMEOUT = 30000L
 
     protected val connectionStarted = AtomicBoolean(false)
     protected val cancelStarted = AtomicBoolean(false)


### PR DESCRIPTION
https://trello.com/c/yXRCsPy4/1382-config-wizard-ab2-thats-never-been-paired-prior-wait-10-seconds-before-tapping-pair-bt-connection-fails