### PR TITLE
Fixed home button strange behaviour

### DIFF
--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -5,16 +5,19 @@
     <item
         android:id="@+id/navigation_dashboard"
         android:icon="@drawable/ic_home_black_24dp"
+        android:menuCategory="secondary"
         android:title="" />
 
     <item
         android:id="@+id/navigation_lets_start"
         android:icon="@drawable/ic_plus_black_24"
+        android:menuCategory="secondary"
         android:title="" />
 
     <item
         android:id="@+id/navigation_settings"
         android:icon="@drawable/ic_settings_black_24dp"
+        android:menuCategory="secondary"
         android:title="" />
 
 </menu>


### PR DESCRIPTION
Now this prevents the strange behaviour that was before when by tapping Record new session button we would go to Let's begin screen, but then we could not go back because the home button would navigate to Let's begin fragment again. As I got it, this has something to do with backstack and "secondary" menu items not being saved there.
Though quite some time has passed before I got what was the problem :)