### PR TITLE
Sd sync issue

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
@@ -51,7 +51,7 @@ interface MeasurementDao {
     @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND measurement_stream_id=:measurementStreamId ORDER BY time DESC LIMIT 1")
     fun lastForStream(sessionId: Long, measurementStreamId: Long): MeasurementDBObject?
 
-    @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND measurement_stream_id=:measurementStreamId ORDER BY time")
+    @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND measurement_stream_id=:measurementStreamId ORDER BY time DESC")
     fun getBySessionIdAndStreamId(sessionId: Long, measurementStreamId: Long): List<MeasurementDBObject?>
 
     @Query("DELETE FROM measurements")

--- a/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
@@ -51,6 +51,9 @@ interface MeasurementDao {
     @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND measurement_stream_id=:measurementStreamId ORDER BY time DESC LIMIT 1")
     fun lastForStream(sessionId: Long, measurementStreamId: Long): MeasurementDBObject?
 
+    @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND measurement_stream_id=:measurementStreamId ORDER BY time")
+    fun getBySessionIdAndStreamId(sessionId: Long, measurementStreamId: Long): List<MeasurementDBObject?>
+
     @Query("DELETE FROM measurements")
     fun deleteAll()
 

--- a/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
@@ -51,7 +51,7 @@ interface MeasurementDao {
     @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND measurement_stream_id=:measurementStreamId ORDER BY time DESC LIMIT 1")
     fun lastForStream(sessionId: Long, measurementStreamId: Long): MeasurementDBObject?
 
-    @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND measurement_stream_id=:measurementStreamId ORDER BY time DESC")
+    @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND measurement_stream_id=:measurementStreamId ORDER BY time")
     fun getBySessionIdAndStreamId(sessionId: Long, measurementStreamId: Long): List<MeasurementDBObject?>
 
     @Query("DELETE FROM measurements")

--- a/app/src/main/java/pl/llp/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/repositories/MeasurementsRepository.kt
@@ -56,6 +56,10 @@ class MeasurementsRepository {
         return mDatabase.measurements().getLastMeasurementsWithGivenAveragingFrequency(streamId, limit, averagingFrequency)
     }
 
+    fun getBySessionIdAndStreamId(sessionId: Long, measurementStreamId: Long): List<MeasurementDBObject?> {
+        return mDatabase.measurements().getBySessionIdAndStreamId(sessionId, measurementStreamId)
+    }
+
     fun deleteMeasurementsOlderThan(
         streamId: Long,
         lastExpectedMeasurementTime: Date

--- a/app/src/main/java/pl/llp/aircasting/di/SensorsModule.kt
+++ b/app/src/main/java/pl/llp/aircasting/di/SensorsModule.kt
@@ -86,10 +86,27 @@ open class SensorsModule {
 
     @Provides
     @Singleton
+    fun providesSDCardFixedSessionsProcessor(
+        csvFileFactory: SDCardCSVFileFactory,
+        csvIterator: SDCardCSVIterator,
+        sessionsRepository: SessionsRepository,
+        measurementStreamsRepository: MeasurementStreamsRepository,
+        measurementsRepository: MeasurementsRepository
+    ): SDCardFixedSessionsProcessor = SDCardFixedSessionsProcessor(
+        csvFileFactory,
+        csvIterator,
+        sessionsRepository,
+        measurementStreamsRepository,
+        measurementsRepository
+    )
+
+    @Provides
+    @Singleton
     fun providesSDCardSyncService(
         sdCardDownloadService: SDCardDownloadService,
         sdCardCSVFileChecker: SDCardCSVFileChecker,
         sdCardMobileSessionsProcessor: SDCardMobileSessionsProcessor,
+        sdCardFixedSessionsProcessor: SDCardFixedSessionsProcessor,
         sessionsSyncService: SessionsSyncService?,
         sdCardUploadFixedMeasurementsService: SDCardUploadFixedMeasurementsService?,
         errorHandler: ErrorHandler
@@ -97,6 +114,7 @@ open class SensorsModule {
         sdCardDownloadService,
         sdCardCSVFileChecker,
         sdCardMobileSessionsProcessor,
+        sdCardFixedSessionsProcessor,
         sessionsSyncService,
         sdCardUploadFixedMeasurementsService,
         errorHandler

--- a/app/src/main/java/pl/llp/aircasting/di/SensorsModule.kt
+++ b/app/src/main/java/pl/llp/aircasting/di/SensorsModule.kt
@@ -70,7 +70,7 @@ open class SensorsModule {
 
     @Provides
     @Singleton
-    fun providesSDCardMeasurementsCreator(
+    fun providesSDCardMobileSessionsProcessor(
         csvFileFactory: SDCardCSVFileFactory,
         csvIterator: SDCardCSVIterator,
         sessionsRepository: SessionsRepository,

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardFixedSessionsProcessor.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardFixedSessionsProcessor.kt
@@ -77,9 +77,6 @@ class SDCardFixedSessionsProcessor(
         val measurementsInDB =
             mMeasurementsRepository.getBySessionIdAndStreamId(sessionId, measurementStreamId)
 
-        // TODO: Should check if all the measurements not present in table
-        // TODO: There should be a faster way of dealing with it
-        // e.g.: binary search in sorted list
         return csvMeasurements.filter { csvMeasurement ->
             isNotAlreadyInDB(csvMeasurement, measurementsInDB)
         }
@@ -89,10 +86,8 @@ class SDCardFixedSessionsProcessor(
         csvMeasurement: CSVMeasurement,
         measurementsInDB: List<MeasurementDBObject?>
     ): Boolean {
-        var noDuplicate = true
-        for (measurement in measurementsInDB) {
-            if (measurement?.time == csvMeasurement.time) noDuplicate = false
-        }
-        return noDuplicate
+        val index = measurementsInDB.binarySearch{it?.time!!.compareTo(csvMeasurement.time)}
+
+        return index < 0
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardFixedSessionsProcessor.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardFixedSessionsProcessor.kt
@@ -67,8 +67,7 @@ class SDCardFixedSessionsProcessor(
         csvMeasurement: CSVMeasurement,
         measurementsInDB: List<MeasurementDBObject?>
     ): Boolean {
-        val index = measurementsInDB.binarySearch{it?.time!!.compareTo(csvMeasurement.time)}
-
+        val index = measurementsInDB.binarySearch{it?.time?.compareTo(csvMeasurement.time) ?: -1}
         return index < 0
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardFixedSessionsProcessor.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardFixedSessionsProcessor.kt
@@ -15,8 +15,6 @@ class SDCardFixedSessionsProcessor(
     private val mMeasurementStreamsRepository: MeasurementStreamsRepository,
     private val mMeasurementsRepository: MeasurementsRepository
 ) {
-    private val mProcessedSessionsIds: MutableList<Long> = mutableListOf()
-
     fun run(deviceId: String) {
         val file = mCSVFileFactory.getFixedFile()
 
@@ -44,9 +42,6 @@ class SDCardFixedSessionsProcessor(
         csvSession.streams.forEach { (headerKey, csvMeasurements) ->
             processMeasurements(deviceId, sessionId, headerKey, csvMeasurements)
         }
-
-        //finishSession(sessionId, session)
-        mProcessedSessionsIds.add(sessionId)
     }
 
     private fun processMeasurements(

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardFixedSessionsProcessor.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardFixedSessionsProcessor.kt
@@ -41,15 +41,9 @@ class SDCardFixedSessionsProcessor(
         csvSession ?: return
 
         val dbSession = mSessionsRepository.getSessionByUUID(csvSession.uuid)
-        val session: Session?
-        val sessionId: Long
+        val sessionId: Long? = dbSession?.id
 
-        if (dbSession == null) {
-            session = csvSession.toSession(deviceId) ?: return
-            sessionId = mSessionsRepository.insert(session)
-        } else {
-            sessionId = dbSession.id
-        }
+        sessionId ?: return
 
         csvSession.streams.forEach { (headerKey, csvMeasurements) ->
             processMeasurements(deviceId, sessionId, headerKey, csvMeasurements)

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardFixedSessionsProcessor.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardFixedSessionsProcessor.kt
@@ -1,0 +1,103 @@
+package pl.llp.aircasting.sensor.airbeam3.sync
+
+import pl.llp.aircasting.database.DatabaseProvider
+import pl.llp.aircasting.database.data_classes.MeasurementDBObject
+import pl.llp.aircasting.database.repositories.MeasurementStreamsRepository
+import pl.llp.aircasting.database.repositories.MeasurementsRepository
+import pl.llp.aircasting.database.repositories.SessionsRepository
+import pl.llp.aircasting.models.Session
+import pl.llp.aircasting.sensor.airbeam3.sync.SDCardCSVFileFactory.Header
+
+class SDCardFixedSessionsProcessor(
+    private val mCSVFileFactory: SDCardCSVFileFactory,
+    private val mSDCardCSVIterator: SDCardCSVIterator,
+    private val mSessionsRepository: SessionsRepository,
+    private val mMeasurementStreamsRepository: MeasurementStreamsRepository,
+    private val mMeasurementsRepository: MeasurementsRepository
+) {
+    private val mProcessedSessionsIds: MutableList<Long> = mutableListOf()
+
+    fun run(deviceId: String) {
+        val file = mCSVFileFactory.getFixedFile()
+
+        DatabaseProvider.runQuery {
+            mSDCardCSVIterator.run(file).forEach { csvSession ->
+                processSession(deviceId, csvSession)
+            }
+        }
+    }
+
+    private fun processSession(deviceId: String, csvSession: CSVSession?) {
+        csvSession ?: return
+
+        val dbSession = mSessionsRepository.getSessionByUUID(csvSession.uuid)
+        val session: Session?
+        val sessionId: Long
+
+        if (dbSession == null) {
+            session = csvSession.toSession(deviceId) ?: return
+            sessionId = mSessionsRepository.insert(session)
+        } else {
+            sessionId = dbSession.id
+        }
+
+        csvSession.streams.forEach { (headerKey, csvMeasurements) ->
+            processMeasurements(deviceId, sessionId, headerKey, csvMeasurements)
+        }
+
+        //finishSession(sessionId, session)
+        mProcessedSessionsIds.add(sessionId)
+    }
+
+    private fun processMeasurements(
+        deviceId: String,
+        sessionId: Long,
+        streamHeaderValue: Int,
+        csvMeasurements: List<CSVMeasurement>
+    ) {
+        val streamHeader = Header.fromInt(streamHeaderValue)
+        val csvMeasurementStream = CSVMeasurementStream.fromHeader(
+            streamHeader
+        ) ?: return
+
+        val measurementStream = csvMeasurementStream.toMeasurementStream(deviceId)
+        val measurementStreamId = mMeasurementStreamsRepository.getIdOrInsert(
+            sessionId,
+            measurementStream
+        )
+
+        // filtering measurements to save only the once we don't already have
+        val filteredCSVMeasurements =
+            filterMeasurements(sessionId, measurementStreamId, csvMeasurements)
+        val measurements =
+            filteredCSVMeasurements.map { csvMeasurement -> csvMeasurement.toMeasurement() }
+        mMeasurementsRepository.insertAll(measurementStreamId, sessionId, measurements)
+    }
+
+    private fun filterMeasurements(
+        sessionId: Long,
+        measurementStreamId: Long,
+        csvMeasurements: List<CSVMeasurement>
+    ): List<CSVMeasurement> {
+        val measurementsInDB =
+            mMeasurementsRepository.getBySessionIdAndStreamId(sessionId, measurementStreamId)
+
+        // TODO: Should check if all the measurements not present in table
+        // TODO: There should be a faster way of dealing with it
+        // e.g.: binary search in sorted list
+        return csvMeasurements.filter { csvMeasurement ->
+            isNotAlreadyInDB(csvMeasurement, measurementsInDB)
+        }
+    }
+
+    private fun isNotAlreadyInDB(
+        csvMeasurement: CSVMeasurement,
+        measurementsInDB: List<MeasurementDBObject?>
+    ): Boolean {
+        var noDuplicate = true
+        for (measurement in measurementsInDB) {
+            if (measurement?.time == csvMeasurement.time) noDuplicate = false
+        }
+        return noDuplicate
+    }
+}

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardMobileSessionsProcessor.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardMobileSessionsProcessor.kt
@@ -6,18 +6,23 @@ import pl.llp.aircasting.database.repositories.MeasurementsRepository
 import pl.llp.aircasting.database.repositories.SessionsRepository
 import pl.llp.aircasting.models.Session
 import pl.llp.aircasting.sensor.airbeam3.sync.SDCardCSVFileFactory.Header
+import java.io.File
 
 class SDCardMobileSessionsProcessor(
-    private val mCSVFileFactory: SDCardCSVFileFactory,
-    private val mSDCardCSVIterator: SDCardCSVIterator,
-    private val mSessionsRepository: SessionsRepository,
-    private val mMeasurementStreamsRepository: MeasurementStreamsRepository,
-    private val mMeasurementsRepository: MeasurementsRepository
+    mCSVFileFactory: SDCardCSVFileFactory,
+    mSDCardCSVIterator: SDCardCSVIterator,
+    mSessionsRepository: SessionsRepository,
+    mMeasurementStreamsRepository: MeasurementStreamsRepository,
+    mMeasurementsRepository: MeasurementsRepository
+) : SDCardSessionsProcessor(
+    mCSVFileFactory,
+    mSDCardCSVIterator,
+    mSessionsRepository,
+    mMeasurementStreamsRepository,
+    mMeasurementsRepository
 ) {
-    private val mProcessedSessionsIds: MutableList<Long> = mutableListOf()
-
-    fun run(deviceId: String, onFinishCallback: (MutableList<Long>) -> Unit) {
-        val file = mCSVFileFactory.getMobileFile()
+    override val file: File
+        get() = mCSVFileFactory.getMobileFile()
 
         DatabaseProvider.runQuery {
             mSDCardCSVIterator.run(file).forEach { csvSession ->
@@ -53,33 +58,21 @@ class SDCardMobileSessionsProcessor(
         }
     }
 
-    private fun processMeasurements(deviceId: String, sessionId: Long, streamHeaderValue: Int, csvMeasurements: List<CSVMeasurement>) {
-        val streamHeader = Header.fromInt(streamHeaderValue)
-        val csvMeasurementStream = CSVMeasurementStream.fromHeader(
-            streamHeader
-        ) ?: return
-
-        val measurementStream = csvMeasurementStream.toMeasurementStream(deviceId)
-        val measurementStreamId = mMeasurementStreamsRepository.getIdOrInsert(
-            sessionId,
-            measurementStream
-        )
-
-        // filtering measurements to save only the once we don't already have
-        val filteredCSVMeasurements = filterMeasurements(sessionId, measurementStreamId, csvMeasurements)
-        val measurements = filteredCSVMeasurements.map { csvMeasurement -> csvMeasurement.toMeasurement() }
-        mMeasurementsRepository.insertAll(measurementStreamId, sessionId, measurements)
-    }
-
-    private fun filterMeasurements(sessionId: Long, measurementStreamId: Long, csvMeasurements: List<CSVMeasurement>): List<CSVMeasurement> {
-        val lastMeasurementTime = mMeasurementsRepository.lastMeasurementTime(sessionId, measurementStreamId) ?: return csvMeasurements
-
-        return csvMeasurements.filter { csvMeasurement -> csvMeasurement.time > lastMeasurementTime }
-    }
-
     private fun finishSession(sessionId: Long, session: Session) {
         val lastMeasurementTime = mMeasurementsRepository.lastMeasurementTime(sessionId)
         session.stopRecording(lastMeasurementTime)
         mSessionsRepository.update(session)
+    }
+
+    override fun filterMeasurements(
+        sessionId: Long,
+        measurementStreamId: Long,
+        csvMeasurements: List<CSVMeasurement>
+    ): List<CSVMeasurement> {
+        val lastMeasurementTime =
+            mMeasurementsRepository.lastMeasurementTime(sessionId, measurementStreamId)
+                ?: return csvMeasurements
+
+        return csvMeasurements.filter { csvMeasurement -> csvMeasurement.time > lastMeasurementTime }
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardMobileSessionsProcessor.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardMobileSessionsProcessor.kt
@@ -24,16 +24,8 @@ class SDCardMobileSessionsProcessor(
     override val file: File
         get() = mCSVFileFactory.getMobileFile()
 
-        DatabaseProvider.runQuery {
-            mSDCardCSVIterator.run(file).forEach { csvSession ->
-                processSession(deviceId, csvSession)
-            }
-
-            onFinishCallback.invoke(mProcessedSessionsIds)
-        }
-    }
-
-    private fun processSession(deviceId: String, csvSession: CSVSession?) {
+    // TODO: Discuss with someone how to derive base implementation of the method in SDCardSessionsProcessor
+    override fun processSession(deviceId: String, csvSession: CSVSession?) {
         csvSession ?: return
 
         val dbSession = mSessionsRepository.getSessionByUUID(csvSession.uuid)

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardSessionsProcessor.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardSessionsProcessor.kt
@@ -1,0 +1,54 @@
+package pl.llp.aircasting.sensor.airbeam3.sync
+
+import pl.llp.aircasting.database.DatabaseProvider
+import pl.llp.aircasting.database.repositories.MeasurementStreamsRepository
+import pl.llp.aircasting.database.repositories.MeasurementsRepository
+import pl.llp.aircasting.database.repositories.SessionsRepository
+import java.io.File
+
+abstract class SDCardSessionsProcessor(
+    val mCSVFileFactory: SDCardCSVFileFactory,
+    val mSDCardCSVIterator: SDCardCSVIterator,
+    val mSessionsRepository: SessionsRepository,
+    private val mMeasurementStreamsRepository: MeasurementStreamsRepository,
+    val mMeasurementsRepository: MeasurementsRepository
+) {
+    abstract val file: File
+    val mProcessedSessionsIds: MutableList<Long> = mutableListOf()
+
+    open fun run(deviceId: String, onFinishCallback: ((MutableList<Long>) -> Unit)? = null) {
+        DatabaseProvider.runQuery {
+            mSDCardCSVIterator.run(file).forEach { csvSession ->
+                processSession(deviceId, csvSession)
+            }
+
+            onFinishCallback?.invoke(mProcessedSessionsIds)
+        }
+    }
+
+    abstract fun processSession(deviceId: String, csvSession: CSVSession?)
+
+    fun processMeasurements(deviceId: String, sessionId: Long, streamHeaderValue: Int, csvMeasurements: List<CSVMeasurement>) {
+        val streamHeader = SDCardCSVFileFactory.Header.fromInt(streamHeaderValue)
+        val csvMeasurementStream = CSVMeasurementStream.fromHeader(
+            streamHeader
+        ) ?: return
+
+        val measurementStream = csvMeasurementStream.toMeasurementStream(deviceId)
+        val measurementStreamId = mMeasurementStreamsRepository.getIdOrInsert(
+            sessionId,
+            measurementStream
+        )
+
+        // filtering measurements to save only the once we don't already have
+        val filteredCSVMeasurements = filterMeasurements(sessionId, measurementStreamId, csvMeasurements)
+        val measurements = filteredCSVMeasurements.map { csvMeasurement -> csvMeasurement.toMeasurement() }
+        mMeasurementsRepository.insertAll(measurementStreamId, sessionId, measurements)
+    }
+
+    abstract fun filterMeasurements(
+        sessionId: Long,
+        measurementStreamId: Long,
+        csvMeasurements: List<CSVMeasurement>
+    ) : List<CSVMeasurement>
+}

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
@@ -20,6 +20,7 @@ class SDCardSyncService(
     private val mSDCardDownloadService: SDCardDownloadService,
     private val mSDCardCSVFileChecker: SDCardCSVFileChecker,
     private val mSDCardMobileSessionsProcessor: SDCardMobileSessionsProcessor,
+    private val mSDCardFixedSessionsProcessor: SDCardFixedSessionsProcessor,
     private val mSessionsSyncService: SessionsSyncService?,
     private val mSDCardUploadFixedMeasurementsService: SDCardUploadFixedMeasurementsService?,
     private val mErrorHandler: ErrorHandler
@@ -69,11 +70,20 @@ class SDCardSyncService(
         if (mSDCardCSVFileChecker.run(steps)) {
             clearSDCard(airBeamConnector)
             saveMobileMeasurementsLocally()
+            saveFixedMeasurementsLocally()
         } else {
             // fatal error, we can't proceed with sync
             handleError(SDCardDownloadedFileCorrupted())
             cleanup()
         }
+    }
+
+    private fun saveFixedMeasurementsLocally() {
+        val deviceItem = mDeviceItem ?: return
+
+        Log.d(TAG, "Processing fixed sessions")
+
+        mSDCardFixedSessionsProcessor.run(deviceItem.id)
     }
 
     private fun handleError(exception: BaseException) {

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
@@ -96,11 +96,10 @@ class SDCardSyncService(
 
         Log.d(TAG, "Processing mobile sessions")
 
-        mSDCardMobileSessionsProcessor.run(deviceItem.id,
-            onFinishCallback = { processedSessionsIds ->
-                sendMobileMeasurementsToBackend(processedSessionsIds)
-            }
-        )
+        mSDCardMobileSessionsProcessor.run(deviceItem.id
+        ) { processedSessionsIds ->
+            sendMobileMeasurementsToBackend(processedSessionsIds)
+        }
     }
 
     private fun sendMobileMeasurementsToBackend(sessionsIds: MutableList<Long>) {

--- a/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
+++ b/app/src/main/java/pl/llp/aircasting/sensor/airbeam3/sync/SDCardSyncService.kt
@@ -40,7 +40,8 @@ class SDCardSyncService(
         3. Check downloaded files (checks if downloaded file has at least 80% of expected lines and if there is at most 20% of corrupted lines)
         4. Save mobile measurements for disconnected sessions in the Android local db. Create sessions named "Imported from SD card" for every UUID that doesn't match with existing session.
         5. Send mobile measurements to the backend using SessionsSyncService.
-        6. Send fixed measurements to the backend - in this case backend knows more than Android app, so we are sending all of them and backend decides what to do with them.
+        6. Save filtered fixed measurements in the Android local db.
+        7. Send fixed measurements to the backend
 
      */
 


### PR DESCRIPTION
This seems to be a working fix for the SD sync measurements not being displayed in Fixed sessions in the App. The idea is to save the necessary (not duplicate fixed measurements locally in DB before sending them to the backend; same as we do with mobile SD sync)