### PR TITLE
Chart left timestamp inaccurate; chart didn't update

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
@@ -63,6 +63,9 @@ interface MeasurementDao {
     @Query("SELECT * FROM measurements WHERE measurement_stream_id=:streamId ORDER BY time DESC LIMIT :limit")
     fun getLastMeasurements(streamId: Long, limit: Int): List<MeasurementDBObject?>
 
+    @Query("SELECT * FROM measurements WHERE measurement_stream_id=:streamId AND time < :time ORDER BY time DESC LIMIT :limit")
+    fun getLastMeasurementsForStreamFromHour(streamId: Long, limit: Int, time: Date): List<MeasurementDBObject?>
+
     @Query("SELECT * FROM measurements WHERE measurement_stream_id=:streamId AND averaging_frequency=:averagingFrequency ORDER BY time DESC LIMIT :limit")
     fun getLastMeasurementsWithGivenAveragingFrequency(streamId: Long, limit: Int, averagingFrequency: Int): List<MeasurementDBObject?>
 

--- a/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
@@ -64,7 +64,7 @@ interface MeasurementDao {
     fun getLastMeasurements(streamId: Long, limit: Int): List<MeasurementDBObject?>
 
     @Query("SELECT * FROM measurements WHERE measurement_stream_id=:streamId AND time < :time ORDER BY time DESC LIMIT :limit")
-    fun getLastMeasurementsForStreamFromHour(streamId: Long, limit: Int, time: Date): List<MeasurementDBObject?>
+    fun getLastMeasurementsForStreamStartingFromHour(streamId: Long, limit: Int, time: Date): List<MeasurementDBObject?>
 
     @Query("SELECT * FROM measurements WHERE measurement_stream_id=:streamId AND averaging_frequency=:averagingFrequency ORDER BY time DESC LIMIT :limit")
     fun getLastMeasurementsWithGivenAveragingFrequency(streamId: Long, limit: Int, averagingFrequency: Int): List<MeasurementDBObject?>

--- a/app/src/main/java/pl/llp/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
@@ -125,13 +125,15 @@ class ActiveSessionMeasurementsRepository {
             val streamId =
                 MeasurementStreamsRepository().getId(sessionId, measurementStream)
 
+            val lastFinishedHour = DateUtils.round(Date(), Calendar.HOUR_OF_DAY)
+
             streamId?.let { streamId ->
                 measurements =
                     measurementsList(
                         MeasurementsRepository().getLastMeasurementsForStreamFromHour(
                             streamId,
                             limit,
-                            DateUtils.round(Date(), Calendar.HOUR_OF_DAY)
+                            lastFinishedHour
                         )
                     )
                 insertAll(streamId, sessionId, measurements)

--- a/app/src/main/java/pl/llp/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
@@ -10,8 +10,8 @@ import java.util.*
 
 class ActiveSessionMeasurementsRepository {
     companion object {
-        // We get 10 hours/minutes of Measurements for chart, to calculate first hour as full
-        const val MAX_MEASUREMENTS_PER_STREAM_NUMBER = 60 * 10
+        // We get 9 hours/minutes of Measurements for chart (we display 9 dots)
+        const val MAX_MEASUREMENTS_PER_STREAM_NUMBER = 60 * 9
     }
 
     private val mDatabase = DatabaseProvider.get()

--- a/app/src/main/java/pl/llp/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
@@ -1,10 +1,12 @@
 package pl.llp.aircasting.database.repositories
 
+import org.apache.commons.lang3.time.DateUtils
 import pl.llp.aircasting.database.DatabaseProvider
 import pl.llp.aircasting.database.data_classes.ActiveSessionMeasurementDBObject
 import pl.llp.aircasting.database.data_classes.MeasurementDBObject
 import pl.llp.aircasting.models.Measurement
 import pl.llp.aircasting.models.MeasurementStream
+import java.util.*
 
 class ActiveSessionMeasurementsRepository {
     companion object {
@@ -126,9 +128,10 @@ class ActiveSessionMeasurementsRepository {
             streamId?.let { streamId ->
                 measurements =
                     measurementsList(
-                        MeasurementsRepository().getLastMeasurementsForStream(
+                        MeasurementsRepository().getLastMeasurementsForStreamFromHour(
                             streamId,
-                            limit
+                            limit,
+                            DateUtils.round(Date(), Calendar.HOUR_OF_DAY)
                         )
                     )
                 insertAll(streamId, sessionId, measurements)

--- a/app/src/main/java/pl/llp/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/repositories/ActiveSessionMeasurementsRepository.kt
@@ -130,7 +130,7 @@ class ActiveSessionMeasurementsRepository {
             streamId?.let { streamId ->
                 measurements =
                     measurementsList(
-                        MeasurementsRepository().getLastMeasurementsForStreamFromHour(
+                        MeasurementsRepository().getLastMeasurementsForStreamStartingFromHour(
                             streamId,
                             limit,
                             lastFinishedHour

--- a/app/src/main/java/pl/llp/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/repositories/MeasurementsRepository.kt
@@ -91,4 +91,8 @@ class MeasurementsRepository {
         return mDatabase.measurements().getByStreamId(streamId)
     }
 
+    fun getLastMeasurementsForStreamFromHour(streamId: Long, limit: Int, time: Date): List<MeasurementDBObject?> {
+        return mDatabase.measurements().getLastMeasurementsForStreamFromHour(streamId, limit, time)
+    }
+
 }

--- a/app/src/main/java/pl/llp/aircasting/database/repositories/MeasurementsRepository.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/repositories/MeasurementsRepository.kt
@@ -91,8 +91,8 @@ class MeasurementsRepository {
         return mDatabase.measurements().getByStreamId(streamId)
     }
 
-    fun getLastMeasurementsForStreamFromHour(streamId: Long, limit: Int, time: Date): List<MeasurementDBObject?> {
-        return mDatabase.measurements().getLastMeasurementsForStreamFromHour(streamId, limit, time)
+    fun getLastMeasurementsForStreamStartingFromHour(streamId: Long, limit: Int, time: Date): List<MeasurementDBObject?> {
+        return mDatabase.measurements().getLastMeasurementsForStreamStartingFromHour(streamId, limit, time)
     }
 
 }


### PR DESCRIPTION
The issue was introduced with previous fixing of chart, where we would grab 10 hours of measurements. This would result in having 10 entries for the chart instead of 9. This caused left timestamp to be calculated incorrectly, as well as not displaying last average on the chart because it wouldn't fill in as 10th one