### PR TITLE
Chart first dot disappearing on refresh 

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/screens/dashboard/charts/ChartData.kt
+++ b/app/src/main/java/pl/llp/aircasting/screens/dashboard/charts/ChartData.kt
@@ -1,10 +1,8 @@
 package pl.llp.aircasting.screens.dashboard.charts
 
 import com.github.mikephil.charting.data.Entry
-import com.google.common.collect.Lists
 import org.apache.commons.lang3.time.DateUtils
 import pl.llp.aircasting.lib.DateConverter
-import pl.llp.aircasting.lib.TemperatureConverter
 import pl.llp.aircasting.models.MeasurementStream
 import pl.llp.aircasting.models.Session
 import pl.llp.aircasting.services.AveragedMeasurementsService
@@ -41,7 +39,7 @@ class ChartData(
 
         mSession = session
         mEndTime = mSession.endTime ?: Date()
-        if(mChartRefreshService.shouldBeRefreshed() || hourChanged) {
+        if(mChartRefreshService.isTimeToRefresh() || hourChanged) {
             initData()
             calculateAverages()
             calculateTimes()

--- a/app/src/main/java/pl/llp/aircasting/screens/dashboard/charts/ChartRefreshService.kt
+++ b/app/src/main/java/pl/llp/aircasting/screens/dashboard/charts/ChartRefreshService.kt
@@ -24,12 +24,8 @@ class ChartRefreshService {
         mLastRefreshTime = System.currentTimeMillis()
     }
 
-    fun shouldBeRefreshed(): Boolean {
-        return when (mSession?.type) {
-            Session.Type.MOBILE -> mLastRefreshTime == null || (timeFromLastRefresh() >= mRefreshFrequency)
-            Session.Type.FIXED -> (Date().minutes == 0) || (timeFromLastRefresh() >= mRefreshFrequency)
-            else -> mLastRefreshTime == null || (timeFromLastRefresh() >= mRefreshFrequency)
-        }
+    fun isTimeToRefresh(): Boolean {
+        return mLastRefreshTime == null || (timeFromLastRefresh() >= mRefreshFrequency)
     }
 
     private fun timeFromLastRefresh(): Long {


### PR DESCRIPTION
This check for current minutes resulted in too early updating of the chart, when the session time is e.g. 10:59 but device's time is 11:00. Which caused ChartData to refresh entries prematurely resulting in having only 8 entries for the chart instead of 9.
Now we refresh fixed sessions based on Session's end time and lastRefreshTime (no device's time)