### PR TITLE
Duplicate measurements in db | Less measurements in chart

### DIFF
--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/17.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/17.json
@@ -214,7 +214,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -224,7 +224,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -267,12 +267,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -289,7 +289,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/18.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/18.json
@@ -226,7 +226,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -236,7 +236,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -279,12 +279,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -301,7 +301,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/19.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/19.json
@@ -226,7 +226,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -236,7 +236,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -279,12 +279,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -301,7 +301,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/20.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/20.json
@@ -232,7 +232,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -242,7 +242,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -285,12 +285,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -307,7 +307,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/21.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/21.json
@@ -244,7 +244,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -254,7 +254,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -297,12 +297,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -319,7 +319,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/22.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/22.json
@@ -250,7 +250,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -260,7 +260,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -303,12 +303,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -325,7 +325,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/23.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/23.json
@@ -262,7 +262,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -272,7 +272,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -315,12 +315,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -337,7 +337,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/24.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/24.json
@@ -262,7 +262,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -272,7 +272,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -315,12 +315,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -337,7 +337,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/25.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/25.json
@@ -268,7 +268,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -278,7 +278,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -327,12 +327,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -349,7 +349,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/26.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/26.json
@@ -268,7 +268,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -278,7 +278,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -327,12 +327,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -349,7 +349,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/27.json
+++ b/app/schemas/io.lunarlogic.aircasting.database.AppDatabase/27.json
@@ -268,7 +268,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -278,7 +278,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -327,12 +327,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -349,7 +349,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/pl.llp.aircasting.database.AppDatabase/27.json
+++ b/app/schemas/pl.llp.aircasting.database.AppDatabase/27.json
@@ -268,7 +268,7 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -278,7 +278,7 @@
           },
           {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -327,12 +327,12 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "createSql": "CREATE  INDEX `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -349,7 +349,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"

--- a/app/schemas/pl.llp.aircasting.database.AppDatabase/28.json
+++ b/app/schemas/pl.llp.aircasting.database.AppDatabase/28.json
@@ -2,18 +2,12 @@
   "formatVersion": 1,
   "database": {
     "version": 28,
-    "identityHash": "3b45815ce88b8dd4e1b0ee787abfebd1",
+    "identityHash": "d458d6212a743418b097226110727f7b",
     "entities": [
       {
         "tableName": "sessions",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uuid` TEXT NOT NULL, `type` INTEGER NOT NULL, `device_id` TEXT, `device_type` INTEGER, `name` TEXT NOT NULL, `tags` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER, `latitude` REAL, `longitude` REAL, `status` INTEGER NOT NULL, `version` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `followed_at` INTEGER, `contribute` INTEGER NOT NULL, `locationless` INTEGER NOT NULL, `url_location` TEXT, `is_indoor` INTEGER NOT NULL, `averaging_frequency` INTEGER NOT NULL, `session_order` INTEGER)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `type` INTEGER NOT NULL, `device_id` TEXT, `device_type` INTEGER, `name` TEXT NOT NULL, `tags` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER, `latitude` REAL, `longitude` REAL, `status` INTEGER NOT NULL, `version` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `followed_at` INTEGER, `contribute` INTEGER NOT NULL, `locationless` INTEGER NOT NULL, `url_location` TEXT, `is_indoor` INTEGER NOT NULL, `averaging_frequency` INTEGER NOT NULL, `session_order` INTEGER, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
         "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
           {
             "fieldPath": "uuid",
             "columnName": "uuid",
@@ -133,6 +127,12 @@
             "columnName": "session_order",
             "affinity": "INTEGER",
             "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -148,7 +148,8 @@
             "columnNames": [
               "device_id"
             ],
-            "createSql": "CREATE  INDEX `index_sessions_device_id` ON `${TABLE_NAME}` (`device_id`)"
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sessions_device_id` ON `${TABLE_NAME}` (`device_id`)"
           },
           {
             "name": "index_sessions_session_order",
@@ -156,21 +157,16 @@
             "columnNames": [
               "session_order"
             ],
-            "createSql": "CREATE  INDEX `index_sessions_session_order` ON `${TABLE_NAME}` (`session_order`)"
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sessions_session_order` ON `${TABLE_NAME}` (`session_order`)"
           }
         ],
         "foreignKeys": []
       },
       {
         "tableName": "measurement_streams",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `session_id` INTEGER NOT NULL, `sensor_package_name` TEXT NOT NULL, `sensor_name` TEXT NOT NULL, `measurement_type` TEXT NOT NULL, `measurement_short_type` TEXT NOT NULL, `unit_name` TEXT NOT NULL, `unit_symbol` TEXT NOT NULL, `threshold_very_low` INTEGER NOT NULL, `threshold_low` INTEGER NOT NULL, `threshold_medium` INTEGER NOT NULL, `threshold_high` INTEGER NOT NULL, `threshold_very_high` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`session_id` INTEGER NOT NULL, `sensor_package_name` TEXT NOT NULL, `sensor_name` TEXT NOT NULL, `measurement_type` TEXT NOT NULL, `measurement_short_type` TEXT NOT NULL, `unit_name` TEXT NOT NULL, `unit_symbol` TEXT NOT NULL, `threshold_very_low` INTEGER NOT NULL, `threshold_low` INTEGER NOT NULL, `threshold_medium` INTEGER NOT NULL, `threshold_high` INTEGER NOT NULL, `threshold_very_high` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
           {
             "fieldPath": "sessionId",
             "columnName": "session_id",
@@ -248,6 +244,12 @@
             "columnName": "deleted",
             "affinity": "INTEGER",
             "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -263,7 +265,8 @@
             "columnNames": [
               "session_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurement_streams_session_id` ON `${TABLE_NAME}` (`session_id`)"
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_measurement_streams_session_id` ON `${TABLE_NAME}` (`session_id`)"
           }
         ],
         "foreignKeys": [
@@ -282,17 +285,11 @@
       },
       {
         "tableName": "measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `measurement_stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, FOREIGN KEY(`measurement_stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
-            "fieldPath": "id",
-            "columnName": "id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
             "fieldPath": "measurementStreamId",
-            "columnName": "measurement_stream_id",
+            "columnName": "stream_id",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -331,6 +328,12 @@
             "columnName": "averaging_frequency",
             "affinity": "INTEGER",
             "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -341,12 +344,13 @@
         },
         "indices": [
           {
-            "name": "index_measurements_measurement_stream_id",
+            "name": "index_measurements_stream_id",
             "unique": false,
             "columnNames": [
-              "measurement_stream_id"
+              "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_measurement_stream_id` ON `${TABLE_NAME}` (`measurement_stream_id`)"
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_measurements_session_id",
@@ -354,7 +358,19 @@
             "columnNames": [
               "session_id"
             ],
-            "createSql": "CREATE  INDEX `index_measurements_session_id` ON `${TABLE_NAME}` (`session_id`)"
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_measurements_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          },
+          {
+            "name": "index_measurements_session_id_stream_id_time",
+            "unique": true,
+            "columnNames": [
+              "session_id",
+              "stream_id",
+              "time"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_measurements_session_id_stream_id_time` ON `${TABLE_NAME}` (`session_id`, `stream_id`, `time`)"
           }
         ],
         "foreignKeys": [
@@ -363,7 +379,7 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
-              "measurement_stream_id"
+              "stream_id"
             ],
             "referencedColumns": [
               "id"
@@ -373,14 +389,8 @@
       },
       {
         "tableName": "sensor_thresholds",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sensor_name` TEXT NOT NULL, `threshold_very_low` INTEGER NOT NULL, `threshold_low` INTEGER NOT NULL, `threshold_medium` INTEGER NOT NULL, `threshold_high` INTEGER NOT NULL, `threshold_very_high` INTEGER NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sensor_name` TEXT NOT NULL, `threshold_very_low` INTEGER NOT NULL, `threshold_low` INTEGER NOT NULL, `threshold_medium` INTEGER NOT NULL, `threshold_high` INTEGER NOT NULL, `threshold_very_high` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
         "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
           {
             "fieldPath": "sensorName",
             "columnName": "sensor_name",
@@ -416,6 +426,12 @@
             "columnName": "threshold_very_high",
             "affinity": "INTEGER",
             "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -431,21 +447,16 @@
             "columnNames": [
               "sensor_name"
             ],
-            "createSql": "CREATE  INDEX `index_sensor_thresholds_sensor_name` ON `${TABLE_NAME}` (`sensor_name`)"
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sensor_thresholds_sensor_name` ON `${TABLE_NAME}` (`sensor_name`)"
           }
         ],
         "foreignKeys": []
       },
       {
         "tableName": "notes",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `session_id` INTEGER NOT NULL, `date` INTEGER NOT NULL, `text` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `number` INTEGER NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`session_id` INTEGER NOT NULL, `date` INTEGER NOT NULL, `text` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `number` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
           {
             "fieldPath": "sessionId",
             "columnName": "session_id",
@@ -481,6 +492,12 @@
             "columnName": "number",
             "affinity": "INTEGER",
             "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -496,7 +513,8 @@
             "columnNames": [
               "session_id"
             ],
-            "createSql": "CREATE  INDEX `index_notes_session_id` ON `${TABLE_NAME}` (`session_id`)"
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_session_id` ON `${TABLE_NAME}` (`session_id`)"
           }
         ],
         "foreignKeys": [
@@ -515,14 +533,8 @@
       },
       {
         "tableName": "active_sessions_measurements",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
           {
             "fieldPath": "streamId",
             "columnName": "stream_id",
@@ -558,6 +570,12 @@
             "columnName": "longitude",
             "affinity": "REAL",
             "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -573,7 +591,8 @@
             "columnNames": [
               "stream_id"
             ],
-            "createSql": "CREATE  INDEX `index_active_sessions_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_active_sessions_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
           },
           {
             "name": "index_active_sessions_measurements_session_id",
@@ -581,7 +600,8 @@
             "columnNames": [
               "session_id"
             ],
-            "createSql": "CREATE  INDEX `index_active_sessions_measurements_session_id` ON `${TABLE_NAME}` (`session_id`)"
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_active_sessions_measurements_session_id` ON `${TABLE_NAME}` (`session_id`)"
           }
         ],
         "foreignKeys": [
@@ -610,9 +630,10 @@
         ]
       }
     ],
+    "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"3b45815ce88b8dd4e1b0ee787abfebd1\")"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd458d6212a743418b097226110727f7b')"
     ]
   }
 }

--- a/app/schemas/pl.llp.aircasting.database.AppDatabase/29.json
+++ b/app/schemas/pl.llp.aircasting.database.AppDatabase/29.json
@@ -1,0 +1,650 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 29,
+    "identityHash": "dee905de55d574bdb991b06c8701b990",
+    "entities": [
+      {
+        "tableName": "sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `type` INTEGER NOT NULL, `device_id` TEXT, `device_type` INTEGER, `name` TEXT NOT NULL, `tags` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER, `latitude` REAL, `longitude` REAL, `status` INTEGER NOT NULL, `version` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `followed_at` INTEGER, `contribute` INTEGER NOT NULL, `locationless` INTEGER NOT NULL, `url_location` TEXT, `is_indoor` INTEGER NOT NULL, `averaging_frequency` INTEGER NOT NULL, `session_order` INTEGER, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deviceType",
+            "columnName": "device_type",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "end_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followed_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contribute",
+            "columnName": "contribute",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationless",
+            "columnName": "locationless",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "urlLocation",
+            "columnName": "url_location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "is_indoor",
+            "columnName": "is_indoor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "averaging_frequency",
+            "columnName": "averaging_frequency",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "session_order",
+            "columnName": "session_order",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_sessions_device_id",
+            "unique": false,
+            "columnNames": [
+              "device_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sessions_device_id` ON `${TABLE_NAME}` (`device_id`)"
+          },
+          {
+            "name": "index_sessions_session_order",
+            "unique": false,
+            "columnNames": [
+              "session_order"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sessions_session_order` ON `${TABLE_NAME}` (`session_order`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "measurement_streams",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`session_id` INTEGER NOT NULL, `sensor_package_name` TEXT NOT NULL, `sensor_name` TEXT NOT NULL, `measurement_type` TEXT NOT NULL, `measurement_short_type` TEXT NOT NULL, `unit_name` TEXT NOT NULL, `unit_symbol` TEXT NOT NULL, `threshold_very_low` INTEGER NOT NULL, `threshold_low` INTEGER NOT NULL, `threshold_medium` INTEGER NOT NULL, `threshold_high` INTEGER NOT NULL, `threshold_very_high` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensorPackageName",
+            "columnName": "sensor_package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensorName",
+            "columnName": "sensor_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "measurementType",
+            "columnName": "measurement_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "measurementShortType",
+            "columnName": "measurement_short_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitName",
+            "columnName": "unit_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitSymbol",
+            "columnName": "unit_symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdVeryLow",
+            "columnName": "threshold_very_low",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdLow",
+            "columnName": "threshold_low",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdMedium",
+            "columnName": "threshold_medium",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdHigh",
+            "columnName": "threshold_high",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdVeryHigh",
+            "columnName": "threshold_very_high",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_measurement_streams_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_measurement_streams_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "measurements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `averaging_frequency` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "measurementStreamId",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "averaging_frequency",
+            "columnName": "averaging_frequency",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_measurements_stream_id",
+            "unique": false,
+            "columnNames": [
+              "stream_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
+          },
+          {
+            "name": "index_measurements_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_measurements_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          },
+          {
+            "name": "index_measurements_session_id_stream_id_time",
+            "unique": true,
+            "columnNames": [
+              "session_id",
+              "stream_id",
+              "time"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_measurements_session_id_stream_id_time` ON `${TABLE_NAME}` (`session_id`, `stream_id`, `time`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "measurement_streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sensor_thresholds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sensor_name` TEXT NOT NULL, `threshold_very_low` INTEGER NOT NULL, `threshold_low` INTEGER NOT NULL, `threshold_medium` INTEGER NOT NULL, `threshold_high` INTEGER NOT NULL, `threshold_very_high` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sensorName",
+            "columnName": "sensor_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdVeryLow",
+            "columnName": "threshold_very_low",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdLow",
+            "columnName": "threshold_low",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdMedium",
+            "columnName": "threshold_medium",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdHigh",
+            "columnName": "threshold_high",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thresholdVeryHigh",
+            "columnName": "threshold_very_high",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_sensor_thresholds_sensor_name",
+            "unique": false,
+            "columnNames": [
+              "sensor_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sensor_thresholds_sensor_name` ON `${TABLE_NAME}` (`sensor_name`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`session_id` INTEGER NOT NULL, `date` INTEGER NOT NULL, `text` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `number` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_notes_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "active_sessions_measurements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_id` INTEGER NOT NULL, `session_id` INTEGER NOT NULL, `value` REAL NOT NULL, `time` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`stream_id`) REFERENCES `measurement_streams`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`session_id`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "streamId",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_active_sessions_measurements_stream_id",
+            "unique": false,
+            "columnNames": [
+              "stream_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_active_sessions_measurements_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
+          },
+          {
+            "name": "index_active_sessions_measurements_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_active_sessions_measurements_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          },
+          {
+            "name": "index_active_sessions_measurements_session_id_stream_id_time",
+            "unique": true,
+            "columnNames": [
+              "session_id",
+              "stream_id",
+              "time"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_active_sessions_measurements_session_id_stream_id_time` ON `${TABLE_NAME}` (`session_id`, `stream_id`, `time`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "measurement_streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dee905de55d574bdb991b06c8701b990')"
+    ]
+  }
+}

--- a/app/src/main/java/pl/llp/aircasting/database/DatabaseProvider.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/DatabaseProvider.kt
@@ -20,7 +20,7 @@ import pl.llp.aircasting.database.migrations.*
         NoteDBObject::class,
         ActiveSessionMeasurementDBObject::class
     ),
-    version = 28,
+    version = 29,
     exportSchema = true
 )
 @TypeConverters(
@@ -67,7 +67,8 @@ class DatabaseProvider {
                     MIGRATION_24_25,
                     MIGRATION_25_26,
                     MIGRATION_26_27,
-                    MIGRATION_27_28
+                    MIGRATION_27_28,
+                    MIGRATION_28_29
                 ).build()
             }
 

--- a/app/src/main/java/pl/llp/aircasting/database/data_classes/active_sessions_measurements.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/data_classes/active_sessions_measurements.kt
@@ -21,7 +21,8 @@ import java.util.*
     ],
     indices = [
         Index("stream_id"),
-        Index("session_id")
+        Index("session_id"),
+        Index(value = ["session_id", "stream_id", "time"], unique = true)
     ]
 )
 data class ActiveSessionMeasurementDBObject(

--- a/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/data_classes/measurements.kt
@@ -9,17 +9,18 @@ import java.util.*
         ForeignKey(
             entity = MeasurementStreamDBObject::class,
             parentColumns = arrayOf("id"),
-            childColumns = arrayOf("measurement_stream_id"),
-            onDelete = ForeignKey.CASCADE
+            childColumns = arrayOf("stream_id"),
+            onDelete = ForeignKey.CASCADE,
         )
     ],
     indices = [
-        Index("measurement_stream_id"),
-        Index("session_id")
+        Index("stream_id"),
+        Index("session_id"),
+        Index(value = ["session_id", "stream_id", "time"], unique = true)
     ]
 )
 data class MeasurementDBObject(
-    @ColumnInfo(name = "measurement_stream_id") val measurementStreamId: Long,
+    @ColumnInfo(name = "stream_id") val streamId: Long,
     @ColumnInfo(name = "session_id") val sessionId: Long,
     @ColumnInfo(name = "value") val value: Double,
     @ColumnInfo(name = "time") val time: Date,
@@ -36,7 +37,7 @@ interface MeasurementDao {
     @Query("SELECT * FROM measurements")
     fun getAll(): List<MeasurementDBObject>
 
-    @Query("SELECT * FROM measurements WHERE measurement_stream_id=:streamId")
+    @Query("SELECT * FROM measurements WHERE stream_id=:streamId")
     fun getByStreamId(streamId: Long): List<MeasurementDBObject>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -48,10 +49,10 @@ interface MeasurementDao {
     @Query("SELECT * FROM measurements WHERE session_id=:sessionId ORDER BY time DESC LIMIT 1")
     fun lastForSession(sessionId: Long): MeasurementDBObject?
 
-    @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND measurement_stream_id=:measurementStreamId ORDER BY time DESC LIMIT 1")
+    @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND stream_id=:measurementStreamId ORDER BY time DESC LIMIT 1")
     fun lastForStream(sessionId: Long, measurementStreamId: Long): MeasurementDBObject?
 
-    @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND measurement_stream_id=:measurementStreamId ORDER BY time")
+    @Query("SELECT * FROM measurements WHERE session_id=:sessionId AND stream_id=:measurementStreamId ORDER BY time")
     fun getBySessionIdAndStreamId(sessionId: Long, measurementStreamId: Long): List<MeasurementDBObject?>
 
     @Query("DELETE FROM measurements")
@@ -60,22 +61,22 @@ interface MeasurementDao {
     @Query("DELETE FROM measurements WHERE session_id=:sessionId AND time < :lastExpectedMeasurementDate ")
     fun delete(sessionId: Long, lastExpectedMeasurementDate: Date)
 
-    @Query("DELETE FROM measurements WHERE measurement_stream_id=:streamId AND id IN (:measurementsIds)")
+    @Query("DELETE FROM measurements WHERE stream_id=:streamId AND id IN (:measurementsIds)")
     fun deleteMeasurements(streamId: Long, measurementsIds: List<Long>)
 
-    @Query("SELECT * FROM measurements WHERE measurement_stream_id=:streamId ORDER BY time DESC LIMIT :limit")
+    @Query("SELECT * FROM measurements WHERE stream_id=:streamId ORDER BY time DESC LIMIT :limit")
     fun getLastMeasurements(streamId: Long, limit: Int): List<MeasurementDBObject?>
 
-    @Query("SELECT * FROM measurements WHERE measurement_stream_id=:streamId AND time < :time ORDER BY time DESC LIMIT :limit")
+    @Query("SELECT * FROM measurements WHERE stream_id=:streamId AND time < :time ORDER BY time DESC LIMIT :limit")
     fun getLastMeasurementsForStreamStartingFromHour(streamId: Long, limit: Int, time: Date): List<MeasurementDBObject?>
 
-    @Query("SELECT * FROM measurements WHERE measurement_stream_id=:streamId AND averaging_frequency=:averagingFrequency ORDER BY time DESC LIMIT :limit")
+    @Query("SELECT * FROM measurements WHERE stream_id=:streamId AND averaging_frequency=:averagingFrequency ORDER BY time DESC LIMIT :limit")
     fun getLastMeasurementsWithGivenAveragingFrequency(streamId: Long, limit: Int, averagingFrequency: Int): List<MeasurementDBObject?>
 
-    @Query("SELECT * FROM measurements WHERE averaging_frequency < :averagingFrequency AND measurement_stream_id=:streamId AND time <:thresholdCrossingTime")
+    @Query("SELECT * FROM measurements WHERE averaging_frequency < :averagingFrequency AND stream_id=:streamId AND time <:thresholdCrossingTime")
     fun getNonAveragedPreviousMeasurements(streamId: Long, averagingFrequency: Int, thresholdCrossingTime: Date): List<MeasurementDBObject>
 
-    @Query("SELECT * FROM measurements WHERE averaging_frequency < :averagingFrequency AND measurement_stream_id=:streamId AND time >:thresholdCrossingTime")
+    @Query("SELECT * FROM measurements WHERE averaging_frequency < :averagingFrequency AND stream_id=:streamId AND time >:thresholdCrossingTime")
     fun getNonAveragedCurrentMeasurements(streamId: Long, averagingFrequency: Int, thresholdCrossingTime: Date): List<MeasurementDBObject>
 
     @Query("SELECT COUNT(id) FROM measurements WHERE averaging_frequency < :newAveragingFrequency AND session_id=:sessionId AND time < :crossingThresholdTime")

--- a/app/src/main/java/pl/llp/aircasting/database/data_classes/sessions.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/data_classes/sessions.kt
@@ -91,7 +91,7 @@ class StreamWithMeasurementsDBObject {
 
     @Relation(
         parentColumn = "id",
-        entityColumn = "measurement_stream_id",
+        entityColumn = "stream_id",
         entity = MeasurementDBObject::class
     )
     lateinit var measurements: List<MeasurementDBObject>

--- a/app/src/main/java/pl/llp/aircasting/database/migrations/migration_29.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/migrations/migration_29.kt
@@ -1,0 +1,19 @@
+package pl.llp.aircasting.database.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_28_29 = object : Migration(28, 29) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(
+            "CREATE UNIQUE INDEX " +
+                    "`unique_index_measurements_duplicates` ON `measurements` " +
+                    "(`session_id`, `stream_id`, `time`)"
+        )
+        database.execSQL(
+            "CREATE UNIQUE INDEX " +
+                    "`unique_index_measurements_duplicates` ON `active_sessions_measurements` " +
+                    "(`session_id`, `stream_id`, `time`)"
+        )
+    }
+}


### PR DESCRIPTION
The issue with graph having less measurements for some sessions was due to duplicates in the DB for these sessions. We already had a onConflict REPLACEMENT policy for duplicate rows, but we did not have Index that would tell SQLite what rows to consider duplicates. I've added a unique Columns combination to tell which rows are considered duplicates - ones that have same session_id, stream_id and time altogether