### PR TITLE
Moving DB setup to Application onCreate() method

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/AircastingApplication.kt
+++ b/app/src/main/java/pl/llp/aircasting/AircastingApplication.kt
@@ -3,6 +3,7 @@ package pl.llp.aircasting
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.ProcessLifecycleOwner
+import pl.llp.aircasting.database.DatabaseProvider
 import pl.llp.aircasting.di.AppModule
 import pl.llp.aircasting.di.PermissionsModule
 import pl.llp.aircasting.lib.Settings
@@ -16,6 +17,9 @@ class AircastingApplication: Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        DatabaseProvider.setup(applicationContext)
+
         mSettings = Settings(this)
         if (mSettings?.isThemeChangeEnabled() == true) AppCompatDelegate.setDefaultNightMode(
             AppCompatDelegate.MODE_NIGHT_YES

--- a/app/src/main/java/pl/llp/aircasting/database/DatabaseProvider.kt
+++ b/app/src/main/java/pl/llp/aircasting/database/DatabaseProvider.kt
@@ -1,5 +1,6 @@
 package pl.llp.aircasting.database
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
@@ -43,11 +44,12 @@ class DatabaseProvider {
     companion object {
         private val DB_NAME = "aircasting"
 
+        @SuppressLint("StaticFieldLeak")
         private lateinit var mContext: Context
         var mAppDatabase: AppDatabase? = null
 
         fun setup(context: Context) {
-            mContext = context
+            mContext = context.applicationContext
         }
 
         fun get(): AppDatabase {

--- a/app/src/main/java/pl/llp/aircasting/screens/main/MainActivity.kt
+++ b/app/src/main/java/pl/llp/aircasting/screens/main/MainActivity.kt
@@ -56,7 +56,6 @@ class MainActivity : BaseActivity(), OnMapsSdkInitializedCallback {
         // subscribing to custom uncaught exception handler to handle crash
         Thread.setDefaultUncaughtExceptionHandler(AircastingUncaughtExceptionHandler(settings))
 
-        DatabaseProvider.setup(applicationContext)
         LocationHelper.setup(applicationContext)
         DateConverter.setup(settings)
         TemperatureConverter.setup(settings)


### PR DESCRIPTION
I believe that the crash with Context not being provided to Database building method could only happen when MainActivity's onCreate() method did not fire (as this is the placed that was used to provide the context to DB), while other processes required DB instance already (e.g. as with SessionsSyncService). 
So I moved the DB setup to Application's onCreate() method (besides we need to provide DB with applicationContext anyway). This method would fire as early as possible (earlier than MainActivity's one).

Having ApplicationContext getter for DB setup should also eliminate possibility of a memory leak