### PR TITLE
Fatal Exception: android.content.ActivityNotFoundException

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/screens/settings/SettingsFragment.kt
+++ b/app/src/main/java/pl/llp/aircasting/screens/settings/SettingsFragment.kt
@@ -23,7 +23,7 @@ class SettingsFragment : BaseFragment<SettingsViewMvcImpl, SettingsController>()
             .appComponent.inject(this)
 
         view = SettingsViewMvcImpl(inflater, container, settings)
-        controller = SettingsController(activity, context, view, settings, childFragmentManager)
+        controller = SettingsController(activity, requireContext(), view, settings, childFragmentManager)
 
         return view?.rootView
     }


### PR DESCRIPTION
This is a fix for the recent crash related to the context in the Settings Activity.