### PR TITLE
Save UI following tab

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsController.kt
@@ -17,13 +17,16 @@ import pl.llp.aircasting.ui.view.screens.new_session.NewSessionActivity
 import pl.llp.aircasting.ui.view.screens.session_view.graph.GraphActivity
 import pl.llp.aircasting.ui.view.screens.session_view.map.MapActivity
 import pl.llp.aircasting.ui.viewmodel.SessionsViewModel
-import pl.llp.aircasting.util.*
+import pl.llp.aircasting.util.CSVHelper
+import pl.llp.aircasting.util.Settings
+import pl.llp.aircasting.util.ShareHelper
 import pl.llp.aircasting.util.events.DeleteSessionEvent
 import pl.llp.aircasting.util.events.DeleteStreamsEvent
 import pl.llp.aircasting.util.events.ExportSessionEvent
 import pl.llp.aircasting.util.events.UpdateSessionEvent
 import pl.llp.aircasting.util.exceptions.ErrorHandler
 import pl.llp.aircasting.util.exceptions.SessionUploadPendingError
+import pl.llp.aircasting.util.showToast
 
 
 abstract class SessionsController(
@@ -145,14 +148,9 @@ abstract class SessionsController(
     override fun onReconnectSessionClicked(session: Session) {}
 
     override fun onExpandSessionCard(session: Session) {
-        expandedCards()?.add(session.uuid)
         mViewMvc?.showLoaderFor(session)
         val finallyCallback = { reloadSession(session) }
         mDownloadMeasurementsService.downloadMeasurements(session, finallyCallback)
-    }
-
-    override fun onCollapseSessionCard(session: Session) {
-        expandedCards()?.remove(session.uuid)
     }
 
     override fun onEditDataPressed(

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsRecyclerAdapter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsRecyclerAdapter.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.runBlocking
 import pl.llp.aircasting.data.model.SensorThreshold
 import pl.llp.aircasting.data.model.Session
 import pl.llp.aircasting.ui.viewmodel.SessionsViewModel
-import pl.llp.aircasting.util.expandedCards
 
 abstract class SessionsRecyclerAdapter<ListenerType>(
     private val mInflater: LayoutInflater,
@@ -61,17 +60,21 @@ abstract class SessionsRecyclerAdapter<ListenerType>(
                 // TODO: Take conditions that ask about refreshing here
                 sessionPresenter.chartData?.refresh(session)
             } else {
-                val sessionPresenter = SessionPresenter(
-                    session,
-                    sensorThresholds,
-                    expanded = expandedCards()?.contains(session.uuid) ?: false
-                )
+                val sessionPresenter = initSessionPresenter(session, sensorThresholds)
                 mSessionPresenters[session.uuid] = sessionPresenter
             }
         }
 
         notifyDataSetChanged()
     }
+
+    protected open fun initSessionPresenter(
+        session: Session,
+        sensorThresholds: HashMap<String, SensorThreshold>
+    ) = SessionPresenter(
+        session,
+        sensorThresholds
+    )
 
     fun showLoaderFor(session: Session) {
         val sessionPresenter = mSessionPresenters[session.uuid]

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/following/FollowingController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/following/FollowingController.kt
@@ -15,6 +15,7 @@ import pl.llp.aircasting.ui.view.screens.search.SearchFixedSessionsActivity
 import pl.llp.aircasting.ui.viewmodel.SessionsViewModel
 import pl.llp.aircasting.util.Settings
 import pl.llp.aircasting.util.adjustMenuVisibility
+import pl.llp.aircasting.util.expandedCards
 
 class FollowingController(
     private val mRootActivity: FragmentActivity?,
@@ -61,6 +62,15 @@ class FollowingController(
     override fun onExploreNewSessionsClicked() {
         val intent = Intent(mContext, SearchFixedSessionsActivity::class.java)
         mContext?.startActivity(intent)
+    }
+
+    override fun onExpandSessionCard(session: Session) {
+        super.onExpandSessionCard(session)
+        expandedCards()?.add(session.uuid)
+    }
+
+    override fun onCollapseSessionCard(session: Session) {
+        expandedCards()?.remove(session.uuid)
     }
 
     override fun onEditSessionClicked(session: Session) {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/following/FollowingRecyclerAdapter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/following/FollowingRecyclerAdapter.kt
@@ -3,15 +3,18 @@ package pl.llp.aircasting.ui.view.screens.dashboard.following
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.app.FragmentManager
+import pl.llp.aircasting.data.model.SensorThreshold
 import pl.llp.aircasting.data.model.Session
 import pl.llp.aircasting.ui.view.screens.dashboard.SessionCardListener
+import pl.llp.aircasting.ui.view.screens.dashboard.SessionPresenter
 import pl.llp.aircasting.ui.view.screens.dashboard.SessionsRecyclerAdapter
+import pl.llp.aircasting.util.expandedCards
 
 open class FollowingRecyclerAdapter(
     private val mInflater: LayoutInflater,
     private val mListener: SessionCardListener,
     supportFragmentManager: FragmentManager
-): SessionsRecyclerAdapter<SessionCardListener>(mInflater, supportFragmentManager) {
+) : SessionsRecyclerAdapter<SessionCardListener>(mInflater, supportFragmentManager) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MyViewHolder {
         val viewMvc =
@@ -22,6 +25,14 @@ open class FollowingRecyclerAdapter(
             )
         viewMvc.registerListener(mListener)
         return MyViewHolder(viewMvc)
+    }
+
+    override fun initSessionPresenter(
+        session: Session,
+        sensorThresholds: HashMap<String, SensorThreshold>
+    ): SessionPresenter {
+        val expandedState = expandedCards()?.contains(session.uuid) ?: false
+        return SessionPresenter(session, sensorThresholds, expanded = expandedState)
     }
 
     override fun prepareSession(session: Session, expanded: Boolean): Session {


### PR DESCRIPTION
This scopes saving card expanded state to following card only. This solves unwanted behaviour with cards on other tabs