### PR TITLE
Binding expanded card correctly

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     kapt(AppDependencies.kaptLibraries)
     kaptAndroidTest(AppDependencies.kaptAndroidTestLibraries)
     androidTestImplementation(AppDependencies.androidTestImplementation)
+    debugImplementation("com.squareup.leakcanary:leakcanary-android:2.9.1")
     // Tests
     testImplementation("junit:junit:4.13.2")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.8.2")

--- a/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
@@ -381,8 +381,8 @@ open class Session(
         return packageNames.distinct().joinToString(", ")
     }
 
-    private fun measurementsCount(): Int {
-        return streams.sumOf { stream -> stream.measurements.size }
+    fun measurementsCount(): Int {
+        return streams.map { stream -> stream.measurements.size }.sum()
     }
 
     fun sharableLocation(): Location? {

--- a/app/src/main/java/pl/llp/aircasting/data/model/observers/SessionsObserver.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/observers/SessionsObserver.kt
@@ -3,12 +3,12 @@ package pl.llp.aircasting.data.model.observers
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
+import kotlinx.coroutines.CoroutineScope
 import pl.llp.aircasting.data.local.DatabaseProvider
 import pl.llp.aircasting.data.model.SensorThreshold
 import pl.llp.aircasting.data.model.Session
-import pl.llp.aircasting.ui.viewmodel.SessionsViewModel
 import pl.llp.aircasting.ui.view.screens.dashboard.SessionsViewMvc
-import kotlinx.coroutines.CoroutineScope
+import pl.llp.aircasting.ui.viewmodel.SessionsViewModel
 
 abstract class SessionsObserver<Type>(
     private val mLifecycleOwner: LifecycleOwner,

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
@@ -144,19 +144,10 @@ abstract class SessionViewMvcImpl<ListenerType>(
         bindChartData()
         bindFollowButtons()
         bindMapButton()
-        bindMeasurementsSelectable(
-            mMeasurementsTableContainer,
-            onExpandSessionCardClickedCallback,
-            expandCardCallback
-        )
+        bindCallbacks()
     }
 
-    protected open fun bindMeasurementsSelectable(
-        mMeasurementsTableContainer: MeasurementsTableContainer,
-        onExpandSessionCardClickedCallback: (() -> Unit?)?,
-        expandCardCallback: (() -> Unit?)?
-    ) {
-        mMeasurementsTableContainer.makeSelectable(mSessionPresenter, showMeasurementsTableValues())
+    protected open fun bindCallbacks() {
         mMeasurementsTableContainer.bindExpandCardCallbacks(
             expandCardCallback,
             onExpandSessionCardClickedCallback
@@ -235,7 +226,7 @@ abstract class SessionViewMvcImpl<ListenerType>(
     protected open fun expandSessionCard() {
         setExpandCollapseButton()
         mExpandedSessionView.visible()
-        if (showExpandedMeasurementsTableValues()) mMeasurementsTableContainer.makeSelectable(mSessionPresenter)
+        mMeasurementsTableContainer.makeSelectable(showExpandedMeasurementsTableValues())
 
         if (showChart()) mChartView?.visible()
 

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
@@ -135,7 +135,8 @@ abstract class SessionViewMvcImpl<ListenerType>(
 
     override fun bindSession(sessionPresenter: SessionPresenter) {
         // TODO: check what is going on with binding measurements table because it is bind 6 times every second
-        bindSelectedStream(sessionPresenter)
+        mSessionPresenter = sessionPresenter
+        bindSelectedStream()
         bindLoader()
         bindExpanded()
         bindSessionDetails()
@@ -170,9 +171,8 @@ abstract class SessionViewMvcImpl<ListenerType>(
         }
     }
 
-    private fun bindSelectedStream(sessionPresenter: SessionPresenter) {
-        mSessionPresenter = sessionPresenter
-        if (mSessionPresenter != null && sessionPresenter.selectedStream == null) {
+    private fun bindSelectedStream() {
+        if (mSessionPresenter != null && mSessionPresenter?.selectedStream == null) {
             mSessionPresenter?.setDefaultStream()
         }
     }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsRecyclerAdapter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsRecyclerAdapter.kt
@@ -115,7 +115,6 @@ abstract class SessionsRecyclerAdapter<ListenerType>(
     fun reloadSession(session: Session) {
         val sessionPresenter = mSessionPresenters[session.uuid]
         sessionPresenter?.session = session
-        notifyItemChanged(mSessionUUIDS.indexOf(session.uuid))
     }
 
     protected fun reloadSessionFromDB(session: Session): Session {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvcImpl.kt
@@ -39,6 +39,7 @@ abstract class SessionsViewMvcImpl<ListenerType>(
         mOnExploreBtn = findViewById(onExploreNewSessionsButtonID())
         mDidYouKnowBox = findViewById(R.id.did_you_know_box)
         mRecyclerSessions = findViewById(R.id.recycler_sessions)
+        mRecyclerSessions?.itemAnimator = null
 
         mRecordSessionButton?.setOnClickListener { onRecordNewSessionClicked() }
         mOnExploreBtn?.setOnClickListener { onExploreNewSessionsClicked() }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/active/DisconnectedView.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/active/DisconnectedView.kt
@@ -41,8 +41,8 @@ class DisconnectedView(
         mReconnectingLoader = rootView?.reconnecting_loader
     }
 
-    fun show(sessionPresenter: SessionPresenter) {
-        val session = sessionPresenter.session
+    fun show(sessionPresenter: SessionPresenter?) {
+        val session = sessionPresenter?.session
         session ?: return
 
         if (session.isAirBeam3()) bindAirBeam3(session) else bindBluetoothDevice(session)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/active/MobileActiveSessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/active/MobileActiveSessionViewMvcImpl.kt
@@ -49,9 +49,9 @@ class MobileActiveSessionViewMvcImpl(
         return ActiveSessionActionsBottomSheet(this, sessionPresenter, mSupportFragmentManager)
     }
 
-    override fun bindExpanded(sessionPresenter: SessionPresenter) {
-        if (sessionPresenter.isDisconnected()) {
-            mDisconnectedView.show(sessionPresenter)
+    override fun bindExpanded() {
+        if (mSessionPresenter?.isDisconnected() == true) {
+            mDisconnectedView.show(mSessionPresenter)
 
             mActionsButton.visibility = View.GONE
             mCollapseSessionButton.visibility = View.GONE
@@ -66,7 +66,7 @@ class MobileActiveSessionViewMvcImpl(
             setExpandCollapseButton()
             mSessionCardLayout.background = null
 
-            super.bindExpanded(sessionPresenter)
+            super.bindExpanded()
         }
     }
 

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/fixed/FixedSessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/fixed/FixedSessionViewMvcImpl.kt
@@ -23,9 +23,9 @@ class FixedSessionViewMvcImpl(
         return false
     }
 
-    override fun bindExpanded(sessionPresenter: SessionPresenter) {
-        if (sessionPresenter.isExternal()) mActionsButton.visibility = View.GONE
-        super.bindExpanded(sessionPresenter)
+    override fun bindExpanded() {
+        if (mSessionPresenter?.isExternal() == true) mActionsButton.visibility = View.GONE
+        super.bindExpanded()
     }
 
     override fun showExpandedMeasurementsTableValues() = true
@@ -45,8 +45,8 @@ class FixedSessionViewMvcImpl(
 
     override fun showChart() = false
 
-    override fun bindFollowButtons(sessionPresenter: SessionPresenter) {
-        if (sessionPresenter.session?.followed == true) {
+    override fun bindFollowButtons() {
+        if (mSessionPresenter?.session?.followed == true) {
             mFollowButton.visibility = View.GONE
             mUnfollowButton.visibility = View.VISIBLE
         } else {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/following/FollowingSessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/following/FollowingSessionViewMvcImpl.kt
@@ -4,7 +4,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import pl.llp.aircasting.R
 import pl.llp.aircasting.ui.view.common.BottomSheet
@@ -38,7 +37,7 @@ open class FollowingSessionViewMvcImpl(
 
     override fun showExpandedMeasurementsTableValues() = true
 
-    override fun bindFollowButtons(sessionPresenter: SessionPresenter) {
+    override fun bindFollowButtons() {
         mUnfollowButton.visible()
         mFollowButton.gone()
     }
@@ -49,22 +48,12 @@ open class FollowingSessionViewMvcImpl(
 
     override fun bindMeasurementsTable() {
         val session = mSessionPresenter?.session
-        val hasMeasurements = session?.hasMeasurements()
-
-        // show MeasurementTable when there are measurements and the noMeasurementView is visible
-        if (session == null || hasMeasurements == true) {
+        if (session == null || session.hasMeasurements()) {
             hideNoMeasurementsInfo()
-            mMeasurementsTableContainer.bindSession(
-                mSessionPresenter,
-                this::onMeasurementStreamChanged
-            )
+            mMeasurementsTableContainer.bindSession(mSessionPresenter, this::onMeasurementStreamChanged)
+        } else {
+            showNoMeasurementsInfo()
         }
-    }
-    // TODO: We'll need to check to see what's happenning with the previously followed sessions which are being bound to the newest one here
-    // It may be also related to the RecyclerView adapter card!
-
-    private fun isNoMeasurementViewVisible(): Boolean {
-        return noMeasurementsIcon?.isVisible == true && noMeasurementsLabels?.isVisible == true
     }
 
     override fun bindCollapsedMeasurementsDescription() {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/new_session/confirmation/ConfirmationController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/new_session/confirmation/ConfirmationController.kt
@@ -7,7 +7,6 @@ import pl.llp.aircasting.data.model.Session
 import pl.llp.aircasting.ui.view.common.BaseController
 import pl.llp.aircasting.util.Settings
 import pl.llp.aircasting.util.events.LocationChanged
-import pl.llp.aircasting.util.extensions.hideKeyboard
 import pl.llp.aircasting.util.extensions.safeRegister
 
 class ConfirmationController(
@@ -27,7 +26,7 @@ class ConfirmationController(
     }
 
     fun onStart(context: Context?) {
-        context?.hideKeyboard()
+        //context?.hideKeyboard()
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -167,7 +167,7 @@ abstract class SessionDetailsViewMvcImpl(
     }
 
     protected open fun onSensorThresholdChanged(sensorThreshold: SensorThreshold) {
-        mMeasurementsTableContainer.refresh()
+        mMeasurementsTableContainer.refresh(mSessionPresenter)
         mStatisticsContainer?.refresh(mSessionPresenter)
 
         mListener?.onSensorThresholdChanged(sensorThreshold)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/measurement_table_container/MeasurementsTableContainer.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/measurement_table_container/MeasurementsTableContainer.kt
@@ -13,7 +13,8 @@ import pl.llp.aircasting.data.model.MeasurementStream
 import pl.llp.aircasting.data.model.Session
 import pl.llp.aircasting.ui.view.screens.dashboard.SessionPresenter
 import pl.llp.aircasting.ui.view.screens.session_view.SelectedSensorBorder
-import pl.llp.aircasting.util.*
+import pl.llp.aircasting.util.MeasurementColor
+import pl.llp.aircasting.util.TemperatureConverter
 import pl.llp.aircasting.util.extensions.gone
 import pl.llp.aircasting.util.extensions.setAppearance
 import pl.llp.aircasting.util.extensions.visible
@@ -65,12 +66,10 @@ abstract class MeasurementsTableContainer {
 
     abstract fun shouldShowSelectedMeasurement(stream: MeasurementStream): Boolean
 
-    fun makeSelectable(sessionPresenter: SessionPresenter? = mSessionPresenter, displayValues: Boolean = true) {
+    fun makeSelectable(displayValues: Boolean = true) {
         mSelectable = true
         mDisplayValues = displayValues
         if (displayValues) mMeasurementValues = mRootView?.measurement_values
-
-        refresh(sessionPresenter)
     }
 
     fun makeCollapsed(sessionPresenter: SessionPresenter? = mSessionPresenter, displayValues: Boolean = true) {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/measurement_table_container/MeasurementsTableContainer.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/measurement_table_container/MeasurementsTableContainer.kt
@@ -65,26 +65,26 @@ abstract class MeasurementsTableContainer {
 
     abstract fun shouldShowSelectedMeasurement(stream: MeasurementStream): Boolean
 
-    fun makeSelectable(displayValues: Boolean = true) {
+    fun makeSelectable(sessionPresenter: SessionPresenter? = mSessionPresenter, displayValues: Boolean = true) {
         mSelectable = true
         mDisplayValues = displayValues
         if (displayValues) mMeasurementValues = mRootView?.measurement_values
 
-        refresh()
+        refresh(sessionPresenter)
     }
 
-    fun makeCollapsed(displayValues: Boolean = true) {
+    fun makeCollapsed(sessionPresenter: SessionPresenter? = mSessionPresenter, displayValues: Boolean = true) {
         resetMeasurementsView()
         mSelectable = true
         mCollapsed = true
 
         mDisplayValues = displayValues
         if (!displayValues && mCollapsed) mMeasurementValues = null
-        refresh()
+        refresh(sessionPresenter)
     }
 
-    fun refresh() {
-        bindSession(mSessionPresenter, mOnMeasurementStreamChanged)
+    fun refresh(sessionPresenter: SessionPresenter?) {
+        bindSession(sessionPresenter, mOnMeasurementStreamChanged)
     }
 
     fun bindSession(


### PR DESCRIPTION
This includes the [pr](https://github.com/HabitatMap/AircastingAndroid/pull/554) so please CR it first :) 
This includes removing the second redundant rebinding when card is expanded, as well as refactoring some of the codes around it