### PR TITLE
Navigation | GoToFollowing Crash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
           name: Test with Firebase Test Lab
           command: >
             sudo gcloud firebase test android run \
-              --device model=hwALE-H,version=21,locale=en,orientation=portrait \
               --device model=SC-02K,version=28,locale=en,orientation=portrait \
               --device model=oriole,version=33,locale=en,orientation=portrait \
               --app ~/project/app/build/outputs/apk/debug/app-debug.apk \

--- a/app/src/main/java/pl/llp/aircasting/ui/view/fragments/search_follow_fixed_session/MapResultFragment.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/fragments/search_follow_fixed_session/MapResultFragment.kt
@@ -185,7 +185,7 @@ class MapResultFragment @Inject constructor(
     }
 
     private fun goToDashboard() {
-        val intent = Intent(activity, MainActivity::class.java)
+        val intent = Intent(requireActivity(), MainActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         startActivity(intent)
     }

--- a/app/src/main/java/pl/llp/aircasting/util/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/extensions/ActivityExtensions.kt
@@ -34,4 +34,5 @@ fun setupAppBar(activity: BaseActivity, toolbar: Toolbar) {
     toolbar.setNavigationOnClickListener {
         activity.onBackPressed()
     }
+    //TODO: replace this later
 }


### PR DESCRIPTION
This was happening when we were starting the MainActivity with new intent and with activity reference which sometimes couldn't find the Navigation so I believe that using `requireActivity()` should solve the problem. This needs to be tested with a physical device again.