### PR TITLE
AB: "PM2.5" should be the default parameter

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
@@ -385,10 +385,6 @@ open class Session(
         return streams.sumOf { stream -> stream.measurements.size }
     }
 
-     fun mStreamsCount(): Int {
-        return streams.size
-    }
-
     fun sharableLocation(): Location? {
         return if (locationless) {
             Location.FAKE_LOCATION

--- a/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
@@ -381,8 +381,12 @@ open class Session(
         return packageNames.distinct().joinToString(", ")
     }
 
-    private fun measurementsCount(): Int {
+     private fun measurementsCount(): Int {
         return streams.sumOf { stream -> stream.measurements.size }
+    }
+
+     fun mStreamsCount(): Int {
+        return streams.size
     }
 
     fun sharableLocation(): Location? {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
@@ -28,7 +28,7 @@ class SessionPresenter() {
         loading: Boolean = false
     ) : this() {
         this.session = session
-        this.selectedStream = selectedStream ?: defaultPm2point5Stream(session)
+        this.selectedStream = selectedStream ?: defaultStream(session)
         this.expanded = expanded
         this.loading = loading
         this.sensorThresholds = sensorThresholds
@@ -65,7 +65,7 @@ class SessionPresenter() {
     }
 
     fun setDefaultStream() {
-        selectedStream = defaultPm2point5Stream(session)
+        selectedStream = defaultStream(session)
     }
 
     fun isFixed(): Boolean {
@@ -104,9 +104,13 @@ class SessionPresenter() {
     }
 
     companion object {
-        fun defaultPm2point5Stream(session: Session?): MeasurementStream? {
+        fun defaultStream(session: Session?): MeasurementStream? {
             val sortedByDetailedType = session?.streamsSortedByDetailedType()
-            return sortedByDetailedType?.find { it.detailedType == SensorName.PM2_5.detailedType }
+            val pm2point5 =
+                sortedByDetailedType?.find { it.detailedType == SensorName.PM2_5.detailedType }
+            val firstStream = sortedByDetailedType?.firstOrNull()
+
+            return pm2point5 ?: firstStream
         }
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
@@ -94,6 +94,10 @@ class SessionPresenter() {
         return session?.isAirBeam3() == true
     }
 
+    fun allStreamsHaveLoaded(): Boolean {
+        return session?.streams?.size == 5
+    }
+
     fun setSensorThresholds(sensorThresholds: List<SensorThreshold>) {
         val hash = hashMapOf<String, SensorThreshold>()
         sensorThresholds.forEach {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
@@ -28,7 +28,7 @@ class SessionPresenter() {
         loading: Boolean = false
     ) : this() {
         this.session = session
-        this.selectedStream = selectedStream ?: defaultStream(session)
+        this.selectedStream = selectedStream ?: defaultPm2point5Stream(session)
         this.expanded = expanded
         this.loading = loading
         this.sensorThresholds = sensorThresholds
@@ -65,7 +65,7 @@ class SessionPresenter() {
     }
 
     fun setDefaultStream() {
-        selectedStream = defaultStream(session)
+        selectedStream = defaultPm2point5Stream(session)
     }
 
     fun isFixed(): Boolean {
@@ -104,13 +104,9 @@ class SessionPresenter() {
     }
 
     companion object {
-        fun defaultStream(session: Session?): MeasurementStream? {
+        fun defaultPm2point5Stream(session: Session?): MeasurementStream? {
             val sortedByDetailedType = session?.streamsSortedByDetailedType()
-            val pm2point5 =
-                sortedByDetailedType?.find { it.detailedType == SensorName.PM2_5.detailedType }
-            val firstStream = sortedByDetailedType?.firstOrNull()
-
-            return pm2point5 ?: firstStream
+            return sortedByDetailedType?.find { it.detailedType == SensorName.PM2_5.detailedType }
         }
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
@@ -136,7 +136,6 @@ abstract class SessionViewMvcImpl<ListenerType>(
     override fun bindSession(sessionPresenter: SessionPresenter) {
         // TODO: check what is going on with binding measurements table because it is bind 6 times every second
         mSessionPresenter = sessionPresenter
-        bindSelectedStream()
 
         bindLoader()
         bindExpanded()
@@ -144,6 +143,10 @@ abstract class SessionViewMvcImpl<ListenerType>(
         bindMeasurementsDescription()
         bindMeasurementsTable()
         bindChartData()
+
+        bindSelectedStream()
+        // we need to set the default stream right after getting/checking all 5 streams.
+
         bindFollowButtons()
         bindMapButton()
         bindCallbacks()
@@ -173,9 +176,12 @@ abstract class SessionViewMvcImpl<ListenerType>(
     }
 
     private fun bindSelectedStream() {
-        if (mSessionPresenter != null && mSessionPresenter?.selectedStream == null) {
+        val session = mSessionPresenter?.session
+
+        if (session?.hasMeasurements() == true && session.mStreamsCount() > 5) {
             mSessionPresenter?.setDefaultStream()
         }
+
     }
 
     private fun bindSessionDetails() {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
@@ -137,6 +137,7 @@ abstract class SessionViewMvcImpl<ListenerType>(
         // TODO: check what is going on with binding measurements table because it is bind 6 times every second
         mSessionPresenter = sessionPresenter
         bindSelectedStream()
+
         bindLoader()
         bindExpanded()
         bindSessionDetails()

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
@@ -134,19 +134,15 @@ abstract class SessionViewMvcImpl<ListenerType>(
     }
 
     override fun bindSession(sessionPresenter: SessionPresenter) {
-        // TODO: check what is going on with binding measurements table because it is bind 6 times every second
         mSessionPresenter = sessionPresenter
 
+        bindSelectedStream()
         bindLoader()
         bindExpanded()
         bindSessionDetails()
         bindMeasurementsDescription()
         bindMeasurementsTable()
         bindChartData()
-
-        bindSelectedStream()
-        // we need to set the default stream right after getting/checking all 5 streams.
-
         bindFollowButtons()
         bindMapButton()
         bindCallbacks()
@@ -176,12 +172,9 @@ abstract class SessionViewMvcImpl<ListenerType>(
     }
 
     private fun bindSelectedStream() {
-        val session = mSessionPresenter?.session
-
-        if (session?.hasMeasurements() == true && session.mStreamsCount() > 5) {
+        if (mSessionPresenter?.selectedStream == null && mSessionPresenter?.allStreamsHaveLoaded() == true) {
             mSessionPresenter?.setDefaultStream()
         }
-
     }
 
     private fun bindSessionDetails() {


### PR DESCRIPTION
So about the problem, I already set the stream to set pm2.5 as the default value, but for some reason, it didn't work for mobile active sessions, now it should be setting for all sessions including mobile active, but I remember that we were facing a problem by setting only to PM2.5, that's why this needs to be fully tested.