### PR TITLE
Fix tests for API28-33

### DIFF
--- a/app/src/androidTest/java/pl/llp/aircasting/helpers/assertions/RecyclerViewItemCountAssertion.kt
+++ b/app/src/androidTest/java/pl/llp/aircasting/helpers/assertions/RecyclerViewItemCountAssertion.kt
@@ -5,7 +5,6 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAssertion
 
-
 class RecyclerViewItemCountAssertion(private val interaction: (Int) -> Boolean) : ViewAssertion {
     override fun check(view: View?, noViewFoundException: NoMatchingViewException?) {
         if (noViewFoundException != null) {

--- a/app/src/main/java/pl/llp/aircasting/di/AppComponent.kt
+++ b/app/src/main/java/pl/llp/aircasting/di/AppComponent.kt
@@ -5,6 +5,7 @@ import pl.llp.aircasting.AircastingApplication
 import pl.llp.aircasting.di.modules.*
 import pl.llp.aircasting.ui.view.common.BaseActivity
 import pl.llp.aircasting.ui.view.fragments.*
+import pl.llp.aircasting.ui.view.fragments.search_follow_fixed_session.MapResultFragment
 import pl.llp.aircasting.ui.view.fragments.search_follow_fixed_session.SearchLocationFragment
 import pl.llp.aircasting.ui.view.screens.create_account.CreateAccountActivity
 import pl.llp.aircasting.ui.view.screens.login.LoginActivity
@@ -73,6 +74,7 @@ interface AppComponent {
     fun inject(fragment: ClearingSDCardFragment)
     fun inject(fragment: SDCardClearedFragment)
     fun inject(fragment: SearchLocationFragment)
+    fun inject(fragment: MapResultFragment)
 
     fun inject(activity: MicrophoneService)
     fun inject(activity: AirBeamRecordSessionService)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/fragments/search_follow_fixed_session/MapResultFragment.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/fragments/search_follow_fixed_session/MapResultFragment.kt
@@ -29,6 +29,7 @@ import com.google.android.libraries.places.api.net.PlacesClient
 import com.google.android.libraries.places.widget.AutocompleteSupportFragment
 import com.google.android.libraries.places.widget.listener.PlaceSelectionListener
 import kotlinx.android.synthetic.main.app_bar.view.*
+import pl.llp.aircasting.AircastingApplication
 import pl.llp.aircasting.R
 import pl.llp.aircasting.data.api.response.search.SessionInRegionResponse
 import pl.llp.aircasting.data.api.response.search.SessionsInRegionsRes
@@ -56,7 +57,9 @@ class MapResultFragment @Inject constructor(
     private var _binding: FragmentSearchFollowResultBinding? = null
     private val binding get() = _binding!!
 
-    private val searchFollowViewModel by activityViewModels<SearchFollowViewModel>(factoryProducer = { factory })
+    private val searchFollowViewModel by activityViewModels<SearchFollowViewModel>(
+        factoryProducer = { factory }
+    )
 
     private lateinit var adapter: FixedFollowAdapter
 
@@ -80,6 +83,8 @@ class MapResultFragment @Inject constructor(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        (activity?.application as AircastingApplication)
+            .appComponent.inject(this)
         _binding = FragmentSearchFollowResultBinding.inflate(inflater, container, false)
         return binding.root
     }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/search/SearchFixedBottomSheet.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/search/SearchFixedBottomSheet.kt
@@ -264,7 +264,7 @@ class SearchFixedBottomSheet : BottomSheet(), OnMapReadyCallback {
         super.onDestroyView()
 
         mapFragment ?: return
-        mapFragment?.let { supportMapFragment ->
+        mapFragment?.parentFragment?.let { supportMapFragment ->
             requireActivity().supportFragmentManager.beginTransaction().remove(supportMapFragment).commit()
         }
     }


### PR DESCRIPTION
Most of the tests were failing because an external session was being followed and never unfollowed.
Also, I've added a few improvements to it; for ex; Running the tests based on the Names order.