### PR TITLE
Ext session reorder wrong positions

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/data/local/repository/SessionsRepository.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/local/repository/SessionsRepository.kt
@@ -182,4 +182,11 @@ class SessionsRepository {
         mDatabase.sessions().updateAveragingFrequency(sessionId, averagingFrequency)
     }
 
+    fun updateFollowedAt(session: Session) {
+        mDatabase.sessions().updateFollowedAt(session.uuid, session.followedAt)
+    }
+
+    fun updateOrder(sessionUUID: String, followingSessionsNumber: Int) {
+        mDatabase.sessions().updateOrder(sessionUUID, followingSessionsNumber)
+    }
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/helpers/SessionFollower.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/helpers/SessionFollower.kt
@@ -1,0 +1,64 @@
+package pl.llp.aircasting.ui.view.screens.dashboard.helpers
+
+import pl.llp.aircasting.data.local.DatabaseProvider
+import pl.llp.aircasting.data.local.repository.ActiveSessionMeasurementsRepository
+import pl.llp.aircasting.data.local.repository.SessionsRepository
+import pl.llp.aircasting.data.model.Session
+import pl.llp.aircasting.util.Settings
+import javax.inject.Inject
+
+class SessionFollower @Inject constructor(
+    private val mSettings: Settings,
+    private val mActiveSessionsRepository: ActiveSessionMeasurementsRepository,
+    private val mSessionRepository: SessionsRepository
+) {
+    fun follow(session: Session) {
+        updateFollowedAt(session)
+
+        addFollowedSessionMeasurementsToActiveTable(session)
+        mSettings.increaseFollowedSessionsNumber()
+    }
+
+    fun unfollow(session: Session) {
+        if (session.isExternal) delete(session)
+        else {
+            updateFollowedAt(session)
+            clearUnfollowedSessionMeasurementsFromActiveTable(session)
+        }
+        mSettings.decreaseFollowedSessionsNumber()
+    }
+
+    private fun updateFollowedAt(session: Session) {
+        DatabaseProvider.runQuery {
+            mSessionRepository.updateFollowedAt(session)
+            mSessionRepository.updateOrder(session.uuid, mSettings.getFollowedSessionsNumber())
+        }
+    }
+
+    private fun addFollowedSessionMeasurementsToActiveTable(session: Session) {
+        DatabaseProvider.runQuery {
+            val sessionId = mSessionRepository.getSessionIdByUUID(session.uuid)
+            sessionId?.let {
+                mActiveSessionsRepository.loadMeasurementsForStreams(
+                    it,
+                    session.streams,
+                    ActiveSessionMeasurementsRepository.MAX_MEASUREMENTS_PER_STREAM_NUMBER
+                )
+            }
+        }
+    }
+
+    private fun delete(session: Session) {
+        DatabaseProvider.runQuery {
+            mSessionRepository.delete(session.uuid)
+        }
+    }
+
+    private fun clearUnfollowedSessionMeasurementsFromActiveTable(session: Session) {
+        DatabaseProvider.runQuery {
+            val sessionId = mSessionRepository.getSessionIdByUUID(session.uuid)
+            mActiveSessionsRepository.deleteBySessionId(sessionId)
+        }
+    }
+}
+

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/search/SearchFixedBottomSheet.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/search/SearchFixedBottomSheet.kt
@@ -12,7 +12,6 @@ import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.material.chip.ChipGroup
 import kotlinx.coroutines.launch
 import pl.llp.aircasting.R
-import pl.llp.aircasting.data.api.response.search.SessionInRegionResponse
 import pl.llp.aircasting.data.model.MeasurementStream
 import pl.llp.aircasting.data.model.SensorThreshold
 import pl.llp.aircasting.data.model.Session
@@ -95,8 +94,7 @@ class SearchFixedBottomSheet : BottomSheet(), OnMapReadyCallback {
 
     private fun setupUnfollowButton() {
         binding?.unfollowBtn?.setOnClickListener {
-            val selectedSession = searchFollowViewModel.selectedSession.value
-            if (selectedSession != null) onUnfollowClicked(selectedSession)
+            onUnfollowClicked()
 
             it.context.showToast(getString(R.string.session_unfollowed))
             toggleFollowButton()
@@ -235,11 +233,11 @@ class SearchFixedBottomSheet : BottomSheet(), OnMapReadyCallback {
     }
 
     private fun onFollowClicked() {
-        searchFollowViewModel.saveSession()
+        searchFollowViewModel.follow()
     }
 
-    private fun onUnfollowClicked(session: SessionInRegionResponse) {
-        searchFollowViewModel.deleteSession(session)
+    private fun onUnfollowClicked() {
+        searchFollowViewModel.unfollow()
     }
 
     private fun showLoader() {

--- a/app/src/main/java/pl/llp/aircasting/ui/viewmodel/SessionsViewModel.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/viewmodel/SessionsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import pl.llp.aircasting.data.local.DatabaseProvider
 import pl.llp.aircasting.data.local.entity.*
+import pl.llp.aircasting.data.local.repository.SessionsRepository
 import pl.llp.aircasting.data.local.repository.ThresholdsRepository
 import pl.llp.aircasting.data.model.MeasurementStream
 import pl.llp.aircasting.data.model.SensorThreshold
@@ -11,7 +12,8 @@ import pl.llp.aircasting.data.model.Session
 
 class SessionsViewModel : ViewModel() {
     private val mDatabase = DatabaseProvider.get()
-    private val thresholdsRepository: ThresholdsRepository = ThresholdsRepository()
+    private val thresholdsRepository = ThresholdsRepository()
+    private val sessionsRepository = SessionsRepository()
 
     fun loadSessionWithMeasurements(uuid: String): LiveData<SessionWithStreamsAndMeasurementsDBObject?> {
         return mDatabase.sessions().loadLiveDataSessionAndMeasurementsByUUID(uuid)
@@ -71,10 +73,10 @@ class SessionsViewModel : ViewModel() {
     }
 
     fun updateFollowedAt(session: Session) {
-        mDatabase.sessions().updateFollowedAt(session.uuid, session.followedAt)
+        sessionsRepository.updateFollowedAt(session)
     }
 
     fun updateOrder(sessionUUID: String, followingSessionsNumber: Int) {
-        mDatabase.sessions().updateOrder(sessionUUID, followingSessionsNumber)
+        sessionsRepository.updateOrder(sessionUUID, followingSessionsNumber)
     }
 }


### PR DESCRIPTION
This shares the functionality of following/unfollowing a session between SessionController and SearchFollowViewModel, which fixes the wrong external sessions' order while in reordering view