### PR TITLE
New session blank screen location permission

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/new_session/NewSessionController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/new_session/NewSessionController.kt
@@ -201,9 +201,13 @@ class NewSessionController(
     fun onRequestPermissionsResult(requestCode: Int, grantResults: IntArray) {
         when (requestCode) {
             ResultCodes.AIRCASTING_PERMISSIONS_REQUEST_LOCATION ->
-                if (permissionsManager.permissionsGranted(grantResults)) needAccessBackgroundLocation() else errorHandler.showError(
-                    R.string.errors_location_services_required
-                )
+                if (permissionsManager.permissionsGranted(grantResults)) needAccessBackgroundLocation()
+                else {
+                    mContextActivity.finish()
+                    errorHandler.showError(
+                        R.string.errors_location_services_required
+                    )
+                }
 
             ResultCodes.AIRCASTING_PERMISSIONS_REQUEST_BACKGROUND_LOCATION -> {
                 if (!permissionsManager.permissionsGranted(grantResults)) errorHandler.showError(

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/new_session/NewSessionController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/new_session/NewSessionController.kt
@@ -205,12 +205,13 @@ class NewSessionController(
                     R.string.errors_location_services_required
                 )
 
-            ResultCodes.AIRCASTING_PERMISSIONS_REQUEST_BACKGROUND_LOCATION ->
-                if (permissionsManager.permissionsGranted(grantResults)) {
-                    goToFirstStep()
-                } else errorHandler.showError(
-                    R.string.errors_location_background_services_required
-                )
+            ResultCodes.AIRCASTING_PERMISSIONS_REQUEST_BACKGROUND_LOCATION -> {
+                if (!permissionsManager.permissionsGranted(grantResults)) errorHandler.showError(
+                        R.string.errors_location_background_services_required
+                    )
+                goToFirstStep()
+            }
+
 
             ResultCodes.AIRCASTING_PERMISSIONS_REQUEST_AUDIO ->
                 if (permissionsManager.permissionsGranted(grantResults)) startMicrophoneSession() else errorHandler.showError(


### PR DESCRIPTION
Before the flow was as follows:

1. Ask for permission 
- if background location permission was not granted -> blank activity screen (but you can still use airbeam by going out and into the wizard)
- if all location permission was denied -> blank screen

How it's happening now:
 1. Ask for permission
- if background location permission was not granted -> go to the connecting to airbeam screen (you do not need to start wizard again)
- if all location permission was denied -> finish NewSessionActivity and go back to the main one (you still have a second chance to grant permissions if you start wizard again)

All informational toasts are displayed as previously