### PR TITLE
iOS like spinner behaviour

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/data/api/services/SessionsSyncService.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/api/services/SessionsSyncService.kt
@@ -89,7 +89,7 @@ class SessionsSyncService private constructor(
         onStartCallback?.invoke()
 
         DatabaseProvider.runQuery {
-            val sessions = sessionRepository.finishedSessions()
+            val sessions = sessionRepository.allSessionsExceptRecording()
             val syncParams = sessions.map { session -> SyncSessionParams(session) }
             val jsonData = gson.toJson(syncParams)
 

--- a/app/src/main/java/pl/llp/aircasting/data/api/services/SessionsSyncService.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/api/services/SessionsSyncService.kt
@@ -81,12 +81,12 @@ class SessionsSyncService private constructor(
         if (syncInBackground.get()) {
             triedToSyncBackground.set(true)
         }
+        onStartCallback?.invoke()
         if (syncStarted.get() || syncInBackground.get() || settings.getIsDeleteSessionInProgress()) {
             return
         }
 
         syncStarted.set(true)
-        onStartCallback?.invoke()
 
         DatabaseProvider.runQuery {
             val sessions = sessionRepository.allSessionsExceptRecording()

--- a/app/src/main/java/pl/llp/aircasting/data/api/services/SessionsSyncService.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/api/services/SessionsSyncService.kt
@@ -14,7 +14,7 @@ import pl.llp.aircasting.data.local.repository.SessionsRepository
 import pl.llp.aircasting.data.model.Session
 import pl.llp.aircasting.util.Settings
 import pl.llp.aircasting.util.events.SessionsSyncErrorEvent
-import pl.llp.aircasting.util.events.SessionsSyncFinishedEvent
+import pl.llp.aircasting.util.events.SessionsSyncEvent
 import pl.llp.aircasting.util.events.SessionsSyncSuccessEvent
 import pl.llp.aircasting.util.exceptions.DBInsertException
 import pl.llp.aircasting.util.exceptions.ErrorHandler
@@ -84,6 +84,7 @@ class SessionsSyncService private constructor(
         }
 
         syncStarted.set(true)
+        EventBus.getDefault().postSticky(SessionsSyncEvent())
 
         DatabaseProvider.runQuery {
             val sessions = sessionRepository.allSessionsExceptRecording()
@@ -113,12 +114,12 @@ class SessionsSyncService private constructor(
                     } else handleSyncError(shouldDisplayErrors, call)
 
                     syncStarted.set(false)
-                    EventBus.getDefault().post(SessionsSyncFinishedEvent())
+                    EventBus.getDefault().postSticky(SessionsSyncEvent(false))
                 }
 
                 override fun onFailure(call: Call<SyncResponse>, t: Throwable) {
                     syncStarted.set(false)
-                    EventBus.getDefault().post(SessionsSyncFinishedEvent())
+                    EventBus.getDefault().postSticky(SessionsSyncEvent(false))
                     handleSyncError(shouldDisplayErrors, call, t)
                 }
             })

--- a/app/src/main/java/pl/llp/aircasting/data/api/services/SessionsSyncService.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/api/services/SessionsSyncService.kt
@@ -78,8 +78,6 @@ class SessionsSyncService private constructor(
     }
 
     fun sync(
-        onStartCallback: (() -> Unit)? = null,
-        finallyCallback: (() -> Unit)? = null,
         shouldDisplayErrors: Boolean = true
     ) {
 
@@ -88,7 +86,6 @@ class SessionsSyncService private constructor(
         if (syncInBackground.get()) {
             triedToSyncBackground.set(true)
         }
-        onStartCallback?.invoke()
         if (syncStarted.get() || syncInBackground.get() || settings.getIsDeleteSessionInProgress()) {
             return
         }
@@ -123,15 +120,12 @@ class SessionsSyncService private constructor(
                     } else handleSyncError(shouldDisplayErrors, call)
 
                     syncStarted.set(false)
-
-                    finallyCallback?.invoke()
-
                     for (listener in listeners) listener.onSyncFinished()
                 }
 
                 override fun onFailure(call: Call<SyncResponse>, t: Throwable) {
                     syncStarted.set(false)
-                    finallyCallback?.invoke()
+                    for (listener in listeners) listener.onSyncFinished()
                     handleSyncError(shouldDisplayErrors, call, t)
                 }
             })

--- a/app/src/main/java/pl/llp/aircasting/data/local/repository/SessionsRepository.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/local/repository/SessionsRepository.kt
@@ -129,7 +129,7 @@ class SessionsRepository {
             .disconnectSession(Session.Status.DISCONNECTED, deviceId, Session.Status.RECORDING)
     }
 
-    fun finishedSessions(): List<Session> {
+    fun allSessionsExceptRecording(): List<Session> {
         return mDatabase.sessions().byStatus(Session.Status.FINISHED)
             .map { dbObject -> Session(dbObject) }
     }

--- a/app/src/main/java/pl/llp/aircasting/data/model/observers/SessionsObserver.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/observers/SessionsObserver.kt
@@ -35,7 +35,6 @@ abstract class SessionsObserver<Type>(
             if (anySessionChanged(sessions)) {
                 onSessionsChanged(coroutineScope, sessions)
             }
-            hideLoader(coroutineScope)
         }
     }
 

--- a/app/src/main/java/pl/llp/aircasting/data/model/observers/SessionsObserver.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/observers/SessionsObserver.kt
@@ -103,12 +103,6 @@ abstract class SessionsObserver<Type>(
         return mSessionsViewModel.findOrCreateSensorThresholds(streams)
     }
 
-    private fun hideLoader(coroutineScope: CoroutineScope) {
-        DatabaseProvider.backToUIThread(coroutineScope) {
-            mViewMvc?.hideLoader()
-        }
-    }
-
     private fun showSessionsView(
         coroutineScope: CoroutineScope,
         modifiedSessions: Map<ModificationType, List<Session>>

--- a/app/src/main/java/pl/llp/aircasting/ui/view/fragments/DashboardFragment.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/fragments/DashboardFragment.kt
@@ -8,20 +8,30 @@ import androidx.activity.addCallback
 import com.google.android.material.tabs.TabLayout
 import kotlinx.android.synthetic.main.fragment_dashboard.*
 import pl.llp.aircasting.AircastingApplication
+import pl.llp.aircasting.data.api.services.ApiServiceFactory
+import pl.llp.aircasting.data.api.services.SessionsSyncService
 import pl.llp.aircasting.ui.view.common.BaseFragment
 import pl.llp.aircasting.ui.view.screens.dashboard.DashboardController
 import pl.llp.aircasting.ui.view.screens.dashboard.DashboardPagerAdapter
 import pl.llp.aircasting.ui.view.screens.dashboard.DashboardViewMvcImpl
-import pl.llp.aircasting.util.*
+import pl.llp.aircasting.util.Settings
+import pl.llp.aircasting.util.exceptions.ErrorHandler
 import pl.llp.aircasting.util.extensions.adjustMenuVisibility
 import pl.llp.aircasting.util.extensions.isIgnoringBatteryOptimizations
 import pl.llp.aircasting.util.extensions.showBatteryOptimizationHelperDialog
+import pl.llp.aircasting.util.isSDKGreaterOrEqualToM
 import javax.inject.Inject
 
 class DashboardFragment : BaseFragment<DashboardViewMvcImpl, DashboardController>() {
 
     @Inject
     lateinit var settings: Settings
+
+    @Inject
+    lateinit var errorHandler: ErrorHandler
+
+    @Inject
+    lateinit var apiServiceFactory: ApiServiceFactory
 
     private var mTabPosition: Int = 0
 
@@ -40,7 +50,12 @@ class DashboardFragment : BaseFragment<DashboardViewMvcImpl, DashboardController
                 it, DashboardPagerAdapter.TABS_COUNT
             )
         }
-        controller = DashboardController(view)
+        val sessionsSyncService = SessionsSyncService.get(
+            apiServiceFactory.get(settings.getAuthToken()!!),
+            errorHandler,
+            settings
+        )
+        controller = DashboardController(view, sessionsSyncService)
         val tabId = arguments?.get("tabId") as Int?
         controller?.onCreate(tabId)
 

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardController.kt
@@ -1,12 +1,22 @@
 package pl.llp.aircasting.ui.view.screens.dashboard
 
+import pl.llp.aircasting.data.api.services.SessionsSyncService
 import pl.llp.aircasting.ui.view.common.BaseController
 
 class DashboardController(
-    private val viewMvc: DashboardViewMvcImpl?
-) : BaseController<DashboardViewMvcImpl>(viewMvc) {
+    private val viewMvc: DashboardViewMvcImpl?,
+    private val sessionsSyncService: SessionsSyncService
+) : BaseController<DashboardViewMvcImpl>(viewMvc), DashboardViewMvc.Listener {
 
     fun onCreate(tabId: Int?) {
         viewMvc?.goToTab(tabId ?: SessionsTab.FOLLOWING.value)
+        viewMvc?.registerListener(this)
+    }
+
+    override fun onSwipeToRefreshTriggered() {
+        sessionsSyncService.sync(
+            { mViewMvc?.showLoader() },
+            { mViewMvc?.hideLoader() }
+        )
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardController.kt
@@ -6,17 +6,24 @@ import pl.llp.aircasting.ui.view.common.BaseController
 class DashboardController(
     private val viewMvc: DashboardViewMvcImpl?,
     private val sessionsSyncService: SessionsSyncService
-) : BaseController<DashboardViewMvcImpl>(viewMvc), DashboardViewMvc.Listener {
+) : BaseController<DashboardViewMvcImpl>(viewMvc), DashboardViewMvc.Listener,
+    SessionsSyncService.Listener {
 
     fun onCreate(tabId: Int?) {
         viewMvc?.goToTab(tabId ?: SessionsTab.FOLLOWING.value)
         viewMvc?.registerListener(this)
+        sessionsSyncService.registerListener(this)
+        onRefreshTriggered()
     }
 
-    override fun onSwipeToRefreshTriggered() {
+    override fun onRefreshTriggered() {
         sessionsSyncService.sync(
             { mViewMvc?.showLoader() },
             { mViewMvc?.hideLoader() }
         )
+    }
+
+    override fun onSyncFinished() {
+        mViewMvc?.hideLoader()
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardController.kt
@@ -4,7 +4,7 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import pl.llp.aircasting.data.api.services.SessionsSyncService
 import pl.llp.aircasting.ui.view.common.BaseController
-import pl.llp.aircasting.util.events.SessionsSyncFinishedEvent
+import pl.llp.aircasting.util.events.SessionsSyncEvent
 import pl.llp.aircasting.util.extensions.safeRegister
 
 class DashboardController(
@@ -16,14 +16,16 @@ class DashboardController(
         viewMvc?.goToTab(tabId ?: SessionsTab.FOLLOWING.value)
         viewMvc?.registerListener(this)
         EventBus.getDefault().safeRegister(this)
-        mViewMvc?.showLoader()
-        sessionsSyncService.sync()
     }
 
     override fun onRefreshTriggered() {
         sessionsSyncService.sync()
     }
 
-    @Subscribe
-    fun onMessageEvent(event: SessionsSyncFinishedEvent) = mViewMvc?.hideLoader()
+    @Subscribe(sticky = true)
+    fun onMessageEvent(initialSync: SessionsSyncEvent) {
+        if (initialSync.inProgress)
+            mViewMvc?.showLoader()
+        else mViewMvc?.hideLoader()
+    }
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardController.kt
@@ -13,14 +13,12 @@ class DashboardController(
         viewMvc?.goToTab(tabId ?: SessionsTab.FOLLOWING.value)
         viewMvc?.registerListener(this)
         sessionsSyncService.registerListener(this)
-        onRefreshTriggered()
+        mViewMvc?.showLoader()
+        sessionsSyncService.sync()
     }
 
     override fun onRefreshTriggered() {
-        sessionsSyncService.sync(
-            { mViewMvc?.showLoader() },
-            { mViewMvc?.hideLoader() }
-        )
+        sessionsSyncService.sync()
     }
 
     override fun onSyncFinished() {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardController.kt
@@ -1,18 +1,21 @@
 package pl.llp.aircasting.ui.view.screens.dashboard
 
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
 import pl.llp.aircasting.data.api.services.SessionsSyncService
 import pl.llp.aircasting.ui.view.common.BaseController
+import pl.llp.aircasting.util.events.SessionsSyncFinishedEvent
+import pl.llp.aircasting.util.extensions.safeRegister
 
 class DashboardController(
     private val viewMvc: DashboardViewMvcImpl?,
     private val sessionsSyncService: SessionsSyncService
-) : BaseController<DashboardViewMvcImpl>(viewMvc), DashboardViewMvc.Listener,
-    SessionsSyncService.Listener {
+) : BaseController<DashboardViewMvcImpl>(viewMvc), DashboardViewMvc.Listener {
 
     fun onCreate(tabId: Int?) {
         viewMvc?.goToTab(tabId ?: SessionsTab.FOLLOWING.value)
         viewMvc?.registerListener(this)
-        sessionsSyncService.registerListener(this)
+        EventBus.getDefault().safeRegister(this)
         mViewMvc?.showLoader()
         sessionsSyncService.sync()
     }
@@ -21,7 +24,6 @@ class DashboardController(
         sessionsSyncService.sync()
     }
 
-    override fun onSyncFinished() {
-        mViewMvc?.hideLoader()
-    }
+    @Subscribe
+    fun onMessageEvent(event: SessionsSyncFinishedEvent) = mViewMvc?.hideLoader()
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardViewMvc.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardViewMvc.kt
@@ -4,4 +4,10 @@ import pl.llp.aircasting.ui.view.common.ViewMvc
 
 interface DashboardViewMvc : ViewMvc {
     fun goToTab(tabId: Int)
+
+    interface Listener {
+        fun onSwipeToRefreshTriggered()
+    }
+    fun showLoader()
+    fun hideLoader()
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardViewMvc.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardViewMvc.kt
@@ -6,7 +6,7 @@ interface DashboardViewMvc : ViewMvc {
     fun goToTab(tabId: Int)
 
     interface Listener {
-        fun onSwipeToRefreshTriggered()
+        fun onRefreshTriggered()
     }
     fun showLoader()
     fun hideLoader()

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/DashboardViewMvcImpl.kt
@@ -66,7 +66,7 @@ class DashboardViewMvcImpl(
 
     private fun onSwipeToRefreshTriggered() {
         for (listener in listeners) {
-            listener.onSwipeToRefreshTriggered()
+            listener.onRefreshTriggered()
         }
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsController.kt
@@ -43,8 +43,6 @@ abstract class SessionsController(
     protected val mErrorHandler = ErrorHandler(mRootActivity!!)
     private val mApiService = mApiServiceFactory.get(mSettings.getAuthToken()!!)
 
-    private val mMobileSessionsSyncService =
-        SessionsSyncService.get(mApiService, mErrorHandler, mSettings)
     private val mDownloadMeasurementsService =
         DownloadMeasurementsService(mApiService, mErrorHandler)
     private val mDownloadService = SessionDownloadService(mApiService, mErrorHandler)
@@ -59,12 +57,9 @@ abstract class SessionsController(
     protected abstract fun registerSessionsObserver()
     protected abstract fun unregisterSessionsObserver()
 
-    open fun onCreate() {
-        mViewMvc?.showLoader()
-    }
+    open fun onCreate() { /* Do nothing */ }
 
     open fun onResume() {
-        mViewMvc?.showLoader()
         registerSessionsObserver()
         mViewMvc?.registerListener(this)
     }
@@ -83,13 +78,6 @@ abstract class SessionsController(
 
     protected fun startNewSession(sessionType: Session.Type) {
         NewSessionActivity.start(mRootActivity, sessionType)
-    }
-
-    override fun onSwipeToRefreshTriggered() {
-        mMobileSessionsSyncService.sync(
-            onStartCallback = { mViewMvc?.showLoader() },
-            finallyCallback = { mViewMvc?.hideLoader() }
-        )
     }
 
     override fun onFollowButtonClicked(session: Session) {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvc.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvc.kt
@@ -12,7 +12,6 @@ interface SessionsViewMvc : ObservableViewMvc<SessionsViewMvc.Listener> {
     interface Listener : FinishSessionListener {
         fun onRecordNewSessionClicked()
         fun onExploreNewSessionsClicked()
-        fun onSwipeToRefreshTriggered()
         fun onDisconnectSessionClicked(session: Session)
         fun addNoteClicked(session: Session)
         fun onReconnectSessionClicked(session: Session)
@@ -38,6 +37,4 @@ interface SessionsViewMvc : ObservableViewMvc<SessionsViewMvc.Listener> {
     fun reloadSession(session: Session)
     fun showReconnectingLoaderFor(session: Session)
     fun hideReconnectingLoaderFor(session: Session)
-    fun showLoader()
-    fun hideLoader()
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvcImpl.kt
@@ -136,7 +136,7 @@ abstract class SessionsViewMvcImpl<ListenerType>(
     }
 
     override fun showLoader() {
-        mSwipeRefreshLayout?.isRefreshing = true
+        //mSwipeRefreshLayout?.isRefreshing = true
     }
 
     override fun hideLoader() {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvcImpl.kt
@@ -9,7 +9,6 @@ import androidx.navigation.Navigation
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.google.android.material.card.MaterialCardView
 import pl.llp.aircasting.R
 import pl.llp.aircasting.data.model.MeasurementStream
@@ -30,7 +29,6 @@ abstract class SessionsViewMvcImpl<ListenerType>(
     protected var mRecyclerSessions: RecyclerView? = null
     private var mEmptyView: View? = null
     protected val mAdapter: SessionsRecyclerAdapter<ListenerType>
-    var mSwipeRefreshLayout: SwipeRefreshLayout? = null
     var mDidYouKnowBox: MaterialCardView? = null
 
     init {
@@ -57,7 +55,6 @@ abstract class SessionsViewMvcImpl<ListenerType>(
             val itemTouchHelper = ItemTouchHelper(itemTouchCallback)
             itemTouchHelper.attachToRecyclerView(mRecyclerSessions)
         }
-        setupSwipeToRefreshLayout()
     }
 
     abstract fun layoutId(): Int
@@ -80,12 +77,6 @@ abstract class SessionsViewMvcImpl<ListenerType>(
     private fun onExploreNewSessionsClicked() {
         for (listener in listeners) {
             listener.onExploreNewSessionsClicked()
-        }
-    }
-
-    private fun onSwipeToRefreshTriggered() {
-        for (listener in listeners) {
-            listener.onSwipeToRefreshTriggered()
         }
     }
 
@@ -135,26 +126,8 @@ abstract class SessionsViewMvcImpl<ListenerType>(
         mAdapter.reloadSession(session)
     }
 
-    override fun showLoader() {
-        //mSwipeRefreshLayout?.isRefreshing = true
-    }
-
-    override fun hideLoader() {
-        mSwipeRefreshLayout?.isRefreshing = false
-    }
-
     private fun recyclerViewCanBeUpdated(): Boolean {
         return mRecyclerSessions?.isComputingLayout == false && mRecyclerSessions?.scrollState == RecyclerView.SCROLL_STATE_IDLE
-    }
-
-    private fun setupSwipeToRefreshLayout() {
-        mSwipeRefreshLayout = rootView?.findViewById(R.id.refresh_sessions)
-        mSwipeRefreshLayout?.let { layout ->
-            layout.setColorSchemeResources(R.color.aircasting_blue_400)
-            layout.setOnRefreshListener {
-                onSwipeToRefreshTriggered()
-            }
-        }
     }
 
     fun onExpandSessionCard(session: Session) {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvcImpl.kt
@@ -77,7 +77,7 @@ abstract class SessionsViewMvcImpl<ListenerType>(
         }
     }
 
-    private fun onExploreNewSessionsClicked(){
+    private fun onExploreNewSessionsClicked() {
         for (listener in listeners) {
             listener.onExploreNewSessionsClicked()
         }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainActivity.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainActivity.kt
@@ -62,7 +62,7 @@ class MainActivity : BaseActivity(), OnMapsSdkInitializedCallback {
 
         view = MainViewMvcImpl(layoutInflater, null, this)
         controller =
-            MainController(this, view!!, settings, apiServiceFactory)
+            MainController(this, settings, apiServiceFactory)
 
         controller?.onCreate()
         setContentView(view?.rootView)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainActivity.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainActivity.kt
@@ -4,22 +4,18 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import androidx.navigation.NavController
-import androidx.navigation.fragment.NavHostFragment
 import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.MapsInitializer.Renderer
 import com.google.android.gms.maps.OnMapsSdkInitializedCallback
 import com.google.android.libraries.places.api.Places
 import pl.llp.aircasting.AircastingApplication
 import pl.llp.aircasting.BuildConfig
-import pl.llp.aircasting.R
 import pl.llp.aircasting.data.api.services.ApiServiceFactory
 import pl.llp.aircasting.ui.view.common.BaseActivity
 import pl.llp.aircasting.util.DateConverter
 import pl.llp.aircasting.util.TemperatureConverter
 import pl.llp.aircasting.util.exceptions.AircastingUncaughtExceptionHandler
 import pl.llp.aircasting.util.extensions.goToFollowingTab
-import pl.llp.aircasting.util.extensions.setupAppBar
 import pl.llp.aircasting.util.helpers.location.LocationHelper
 import javax.inject.Inject
 
@@ -29,8 +25,6 @@ class MainActivity : BaseActivity(), OnMapsSdkInitializedCallback {
 
     @Inject
     lateinit var apiServiceFactory: ApiServiceFactory
-
-    private lateinit var mNavController: NavController
 
     companion object {
         fun start(context: Context?) {
@@ -66,21 +60,8 @@ class MainActivity : BaseActivity(), OnMapsSdkInitializedCallback {
 
         controller?.onCreate()
         setContentView(view?.rootView)
-
-        view?.apply {
-            appBarSetup()
-            setupNavController()
-            setupBottomNavigationBar(mNavController)
-        }
     }
 
-    private fun setupNavController() {
-        val navHostFragment =
-            supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
-        mNavController = navHostFragment.navController
-
-        view?.setupNavController(mNavController)
-    }
 
     override fun onResume() {
         super.onResume()

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainController.kt
@@ -3,35 +3,27 @@ package pl.llp.aircasting.ui.view.screens.main
 import android.content.IntentFilter
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.FragmentManager
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
-import pl.llp.aircasting.MobileNavigationDirections
-import pl.llp.aircasting.data.api.services.ApiService
 import pl.llp.aircasting.data.api.services.ApiServiceFactory
 import pl.llp.aircasting.data.api.services.ConnectivityManager
-import pl.llp.aircasting.data.api.services.SessionsSyncService
-import pl.llp.aircasting.data.local.DatabaseProvider
-import pl.llp.aircasting.data.local.repository.SessionsRepository
 import pl.llp.aircasting.data.model.Session
-import pl.llp.aircasting.ui.view.screens.dashboard.SessionsTab
 import pl.llp.aircasting.ui.view.screens.login.LoginActivity
 import pl.llp.aircasting.ui.view.screens.new_session.NewSessionActivity
 import pl.llp.aircasting.ui.view.screens.onboarding.OnboardingActivity
 import pl.llp.aircasting.ui.view.screens.sync.SyncActivity
-import pl.llp.aircasting.util.*
+import pl.llp.aircasting.util.ResultCodes
+import pl.llp.aircasting.util.Settings
 import pl.llp.aircasting.util.events.DisconnectExternalSensorsEvent
 import pl.llp.aircasting.util.events.KeepScreenOnToggledEvent
 import pl.llp.aircasting.util.events.LocationPermissionsResultEvent
 import pl.llp.aircasting.util.exceptions.ErrorHandler
 import pl.llp.aircasting.util.extensions.goToDormantTab
-import pl.llp.aircasting.util.extensions.goToFollowingTab
 import pl.llp.aircasting.util.extensions.safeRegister
 import pl.llp.aircasting.util.helpers.sensor.SessionManager
 
 class MainController(
     private val rootActivity: AppCompatActivity,
-    private val mViewMvc: MainViewMvc,
     private val mSettings: Settings,
     private val mApiServiceFactory: ApiServiceFactory
 ) {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainController.kt
@@ -5,8 +5,10 @@ import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
+import pl.llp.aircasting.data.api.services.ApiService
 import pl.llp.aircasting.data.api.services.ApiServiceFactory
 import pl.llp.aircasting.data.api.services.ConnectivityManager
+import pl.llp.aircasting.data.api.services.SessionsSyncService
 import pl.llp.aircasting.data.model.Session
 import pl.llp.aircasting.ui.view.screens.login.LoginActivity
 import pl.llp.aircasting.ui.view.screens.new_session.NewSessionActivity
@@ -76,6 +78,15 @@ class MainController(
 
         mConnectivityManager = ConnectivityManager(apiService, rootActivity, mSettings)
         registerConnectivityManager()
+
+        sync(apiService)
+    }
+
+    private fun sync(apiService: ApiService) {
+        val syncService =
+            SessionsSyncService.get(apiService, mErrorHandler, mSettings)
+
+        syncService.sync()
     }
 
     private fun goToDormantTab() {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainController.kt
@@ -84,18 +84,6 @@ class MainController(
 
         mConnectivityManager = ConnectivityManager(apiService, rootActivity, mSettings)
         registerConnectivityManager()
-
-        sync(apiService)
-    }
-
-    private fun sync(apiService: ApiService) {
-        val mMobileSessionsSyncService =
-            SessionsSyncService.get(apiService, mErrorHandler, mSettings)
-
-        mMobileSessionsSyncService.sync(
-            onStartCallback = { mViewMvc.showLoader() },
-            finallyCallback = { mViewMvc.hideLoader() }
-        )
     }
 
     private fun goToDormantTab() {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainViewMvc.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainViewMvc.kt
@@ -1,8 +1,0 @@
-package pl.llp.aircasting.ui.view.screens.main
-
-import pl.llp.aircasting.ui.view.common.ViewMvc
-
-interface MainViewMvc: ViewMvc {
-    fun showLoader()
-    fun hideLoader()
-}

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainViewMvcImpl.kt
@@ -30,8 +30,7 @@ class MainViewMvcImpl(
     inflater: LayoutInflater,
     parent: ViewGroup?,
     private val rootActivity: AppCompatActivity
-) : BaseViewMvc(), MainViewMvc {
-    private val loader: ImageView?
+) : BaseViewMvc() {
     private val mSessionRepository = SessionsRepository()
     private var mSettings: Settings? = null
 
@@ -46,7 +45,6 @@ class MainViewMvcImpl(
 
     init {
         this.rootView = inflater.inflate(R.layout.activity_main, parent, false)
-        this.loader = rootView?.loader
         mSettings = Settings(rootActivity.application)
 
         rootView?.apply {
@@ -148,15 +146,5 @@ class MainViewMvcImpl(
     private fun goToFollowingTab() {
         val action = MobileNavigationDirections.actionGlobalDashboard(SessionsTab.FOLLOWING.value)
         mNavController.navigate(action)
-    }
-
-    override fun showLoader() {
-        loader?.startAnimation()
-    }
-
-    override fun hideLoader() {
-        Handler(Looper.getMainLooper()).postDelayed({
-            loader?.stopAnimation()
-        }, 10000)
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainViewMvcImpl.kt
@@ -1,8 +1,6 @@
 package pl.llp.aircasting.ui.view.screens.main
 
 import android.content.Intent
-import android.os.Handler
-import android.os.Looper
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.Button
@@ -10,12 +8,12 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import kotlinx.android.synthetic.main.activity_main.view.*
 import pl.llp.aircasting.MobileNavigationDirections
 import pl.llp.aircasting.R
 import pl.llp.aircasting.data.local.DatabaseProvider
@@ -24,7 +22,9 @@ import pl.llp.aircasting.ui.view.common.BaseViewMvc
 import pl.llp.aircasting.ui.view.screens.dashboard.SessionsTab
 import pl.llp.aircasting.ui.view.screens.search.SearchFixedSessionActivity
 import pl.llp.aircasting.util.Settings
-import pl.llp.aircasting.util.extensions.*
+import pl.llp.aircasting.util.extensions.adjustMenuVisibility
+import pl.llp.aircasting.util.extensions.gone
+import pl.llp.aircasting.util.extensions.visible
 
 class MainViewMvcImpl(
     inflater: LayoutInflater,
@@ -58,14 +58,19 @@ class MainViewMvcImpl(
 
             mFinishedReorderingSessionsButton =
                 findViewById(R.id.finished_reordering_session_button)
+
+            appBarSetup()
+            setupNavController()
+            setupBottomNavigationBar()
         }
     }
 
-    fun setupNavController(navController: NavController) {
-        mNavController = navController
+    private fun setupNavController() {
+        val navHostFragment =
+            rootActivity.supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        mNavController = navHostFragment.navController
     }
-
-    fun appBarSetup() {
+    private fun appBarSetup() {
         setupTopAppBar()
 
         mReorderSessionsButton.setOnClickListener { onReorderSessionsClicked() }
@@ -101,7 +106,7 @@ class MainViewMvcImpl(
         mReorderLayout.visible()
     }
 
-    fun setupBottomNavigationBar(navController: NavController) {
+    private fun setupBottomNavigationBar() {
         val navView: BottomNavigationView = findViewById(R.id.nav_view)
         val appBarConfiguration = AppBarConfiguration(
             setOf(
@@ -110,8 +115,8 @@ class MainViewMvcImpl(
                 R.id.navigation_settings
             )
         )
-        rootActivity.setupActionBarWithNavController(navController, appBarConfiguration)
-        navView.setupWithNavController(navController)
+        rootActivity.setupActionBarWithNavController(mNavController, appBarConfiguration)
+        navView.setupWithNavController(mNavController)
         navView.setOnItemSelectedListener { item ->
             when (item.itemId) {
                 R.id.navigation_dashboard -> {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/main/MainViewMvcImpl.kt
@@ -154,7 +154,6 @@ class MainViewMvcImpl(
         loader?.startAnimation()
     }
 
-    // TODO: The recyclerView needs to be improved later.
     override fun hideLoader() {
         Handler(Looper.getMainLooper()).postDelayed({
             loader?.stopAnimation()

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/sync/SyncController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/sync/SyncController.kt
@@ -26,8 +26,8 @@ import pl.llp.aircasting.util.ResultCodes
 import pl.llp.aircasting.util.Settings
 import pl.llp.aircasting.util.events.AirBeamConnectionFailedEvent
 import pl.llp.aircasting.util.events.sdcard.SDCardSyncErrorEvent
-import pl.llp.aircasting.util.events.sessions_sync.SessionsSyncErrorEvent
-import pl.llp.aircasting.util.events.sessions_sync.SessionsSyncSuccessEvent
+import pl.llp.aircasting.util.events.SessionsSyncErrorEvent
+import pl.llp.aircasting.util.events.SessionsSyncSuccessEvent
 import pl.llp.aircasting.util.exceptions.ErrorHandler
 import pl.llp.aircasting.util.exceptions.SDCardSyncError
 import pl.llp.aircasting.util.extensions.areLocationServicesOn

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/sync/SyncController.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/sync/SyncController.kt
@@ -103,7 +103,7 @@ class SyncController(
 
     private fun refreshSessionList() {
         mSessionsSyncStarted.set(true)
-        mSessionsSyncService.sync(shouldDisplayErrors = false)
+        mSessionsSyncService.sync(false)
     }
 
     @Subscribe

--- a/app/src/main/java/pl/llp/aircasting/util/events/SyncEvents.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/events/SyncEvents.kt
@@ -1,0 +1,5 @@
+package pl.llp.aircasting.util.events
+
+class SessionsSyncErrorEvent
+class SessionsSyncSuccessEvent
+class SessionsSyncFinishedEvent

--- a/app/src/main/java/pl/llp/aircasting/util/events/SyncEvents.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/events/SyncEvents.kt
@@ -1,5 +1,7 @@
 package pl.llp.aircasting.util.events
 
+class SessionsSyncEvent(private val isInProgress: Boolean = true) {
+    val inProgress get() = isInProgress
+}
 class SessionsSyncErrorEvent
 class SessionsSyncSuccessEvent
-class SessionsSyncFinishedEvent

--- a/app/src/main/java/pl/llp/aircasting/util/events/sessions_sync/SessionsSyncErrorEvent.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/events/sessions_sync/SessionsSyncErrorEvent.kt
@@ -1,3 +1,0 @@
-package pl.llp.aircasting.util.events.sessions_sync
-
-class SessionsSyncErrorEvent

--- a/app/src/main/java/pl/llp/aircasting/util/events/sessions_sync/SessionsSyncSuccessEvent.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/events/sessions_sync/SessionsSyncSuccessEvent.kt
@@ -1,3 +1,0 @@
-package pl.llp.aircasting.util.events.sessions_sync
-
-class SessionsSyncSuccessEvent

--- a/app/src/main/java/pl/llp/aircasting/util/helpers/sensor/SessionManager.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/helpers/sensor/SessionManager.kt
@@ -134,8 +134,8 @@ class SessionManager(
             updateMobileSessions()
             settings.setAppNotRestarted()
         }
-        fixedSessionDownloadMeasurementsService.start()
         periodicallySyncSessionsService.start()
+        fixedSessionDownloadMeasurementsService.start()
     }
 
     fun onStop() {

--- a/app/src/main/java/pl/llp/aircasting/util/helpers/sensor/airbeam3/sync/SDCardSyncService.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/helpers/sensor/airbeam3/sync/SDCardSyncService.kt
@@ -9,8 +9,8 @@ import pl.llp.aircasting.ui.view.screens.new_session.select_device.DeviceItem
 import pl.llp.aircasting.util.events.sdcard.SDCardLinesReadEvent
 import pl.llp.aircasting.util.events.sdcard.SDCardSyncErrorEvent
 import pl.llp.aircasting.util.events.sdcard.SDCardSyncFinished
-import pl.llp.aircasting.util.events.sessions_sync.SessionsSyncErrorEvent
-import pl.llp.aircasting.util.events.sessions_sync.SessionsSyncSuccessEvent
+import pl.llp.aircasting.util.events.SessionsSyncErrorEvent
+import pl.llp.aircasting.util.events.SessionsSyncSuccessEvent
 import pl.llp.aircasting.util.exceptions.*
 import pl.llp.aircasting.util.helpers.sensor.AirBeamConnector
 import pl.llp.aircasting.util.extensions.safeRegister

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -6,19 +6,29 @@
     android:layout_height="match_parent"
     android:background="@drawable/dashboard_background">
 
-    <androidx.viewpager.widget.ViewPager
-        android:id="@+id/pager"
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tabs"
+        style="@style/Widget.Aircasting.TabLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content"
+        android:paddingEnd="@dimen/keyline_4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tabMode="scrollable" />
 
-        <com.google.android.material.tabs.TabLayout
-            android:id="@+id/tabs"
-            style="@style/Widget.Aircasting.TabLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingEnd="@dimen/keyline_4"
-            app:layout_constraintBottom_toTopOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tabMode="scrollable" />
-    </androidx.viewpager.widget.ViewPager>
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/refresh_sessions"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tabs"
+        app:layout_constraintVertical_bias="0.479">
+
+        <androidx.viewpager.widget.ViewPager
+            android:id="@+id/pager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -13,6 +13,7 @@
         android:layout_height="wrap_content"
         android:paddingEnd="@dimen/keyline_4"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:tabMode="scrollable" />
 
@@ -21,9 +22,9 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tabs"
-        app:layout_constraintVertical_bias="0.479">
+        app:layout_constraintTop_toBottomOf="@+id/tabs">
 
         <androidx.viewpager.widget.ViewPager
             android:id="@+id/pager"

--- a/app/src/main/res/layout/fragment_sessions_tab.xml
+++ b/app/src/main/res/layout/fragment_sessions_tab.xml
@@ -4,18 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/refresh_sessions"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_sessions"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_sessions"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <include
         android:id="@+id/empty_dashboard"

--- a/app/src/main/res/layout/hlu_slider.xml
+++ b/app/src/main/res/layout/hlu_slider.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/hlu"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    app:layout_constraintBottom_toBottomOf="parent">
 
     <ImageView
         android:id="@+id/more_button"

--- a/app/src/main/res/layout/hlu_slider.xml
+++ b/app/src/main/res/layout/hlu_slider.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/hlu"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:layout_constraintBottom_toBottomOf="parent">
+    android:layout_height="wrap_content">
 
     <ImageView
         android:id="@+id/more_button"


### PR DESCRIPTION
This includes spinner behaviour like in iOS - meaning that we will only have one spinner for Sync operation that will live across tabs on the dashboard, along with some major-ish refactor of the touched parts.

Some of the changes in structure that were made during the implementation process:
- Remove spinner handling from anywhere except Dashboard components (Mvc, Controller)
- Moving SwipeRefreshLayout from tabs (as there were 4 layout tabs programmatically created we had 4 Swipe layouts and 4 spinners) to Dashboard layout, so that we have ViewPager with 4 tabs inside a SwipeRefreshLayout, and swipe down on a ViewPager triggers the sync and spinner (when you are at the top of the list only). 
As the SwipeRefreshLayout appears right from the top of its child layout, it was placed in the Dashboard layout.
- Moving initial Sync operation when the user logs in from Main components (Controller) to Dashboard components. 
This was needed to be done as we want the spinner to be tied to initial sync operation on log in - and we will not able to notify it about sync getting started otherwise because at the moment Main controller is calling a sync operation the Dashboard (along with spinner) is not yet drawn, and its components are not yet instantiated - so they will not get notified about the initial sync. That's why the initial sync got transferred there - so the spinner operation is tied to it