### PR TITLE
Sessions list scroll on update crash

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/data/model/observers/SessionsObserver.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/observers/SessionsObserver.kt
@@ -10,6 +10,7 @@ import pl.llp.aircasting.ui.view.screens.dashboard.SessionsViewMvc
 import pl.llp.aircasting.ui.viewmodel.SessionsViewModel
 import pl.llp.aircasting.util.extensions.backToUIThread
 import pl.llp.aircasting.util.extensions.runOnIOThread
+import java.util.concurrent.ConcurrentHashMap
 
 abstract class SessionsObserver<Type>(
     private val mLifecycleOwner: LifecycleOwner,
@@ -22,9 +23,9 @@ abstract class SessionsObserver<Type>(
         INSERTED
     }
 
-    private var mSessions = hashMapOf<String, Session>()
-    private var mSensorThresholds = hashMapOf<String, SensorThreshold>()
-    private var modifiedSessions = HashMap<ModificationType, List<Session>>()
+    private var mSessions = ConcurrentHashMap<String, Session>()
+    private var mSensorThresholds = ConcurrentHashMap<String, SensorThreshold>()
+    private var modifiedSessions = ConcurrentHashMap<ModificationType, List<Session>>()
 
     private var mSessionsLiveData: LiveData<List<Type>>? = null
 
@@ -63,7 +64,7 @@ abstract class SessionsObserver<Type>(
     }
 
     private fun searchForModifiedSessions(sessions: List<Session>): Map<ModificationType, List<Session>> {
-        val modified = HashMap<ModificationType, List<Session>>()
+        val modified = ConcurrentHashMap<ModificationType, List<Session>>()
         modified[ModificationType.DELETED] = deleted(sessions)
         modified[ModificationType.INSERTED] = inserted(sessions)
         modified[ModificationType.UPDATED] = updated(sessions)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
@@ -10,7 +10,7 @@ import java.util.*
 class SessionPresenter() {
     var session: Session? = null
     var selectedStream: MeasurementStream? = null
-    var sensorThresholds: HashMap<String, SensorThreshold> = hashMapOf()
+    var sensorThresholds: Map<String, SensorThreshold> = hashMapOf()
     var expanded: Boolean = false
     var loading: Boolean = false
     var reconnecting: Boolean = false
@@ -22,7 +22,7 @@ class SessionPresenter() {
 
     constructor(
         session: Session,
-        sensorThresholds: HashMap<String, SensorThreshold>,
+        sensorThresholds: Map<String, SensorThreshold>,
         selectedStream: MeasurementStream? = null,
         expanded: Boolean = false,
         loading: Boolean = false

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsRecyclerAdapter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsRecyclerAdapter.kt
@@ -4,7 +4,6 @@ import android.view.LayoutInflater
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -53,7 +52,7 @@ abstract class SessionsRecyclerAdapter<ListenerType>(
 
     fun bindSessions(
         modifiedSessions: Map<SessionsObserver.ModificationType, List<Session>>,
-        sensorThresholds: HashMap<String, SensorThreshold>
+        sensorThresholds: Map<String, SensorThreshold>
     ) {
         delete(modifiedSessions[SessionsObserver.ModificationType.DELETED])
         update(modifiedSessions[SessionsObserver.ModificationType.UPDATED])
@@ -85,7 +84,7 @@ abstract class SessionsRecyclerAdapter<ListenerType>(
 
     private fun insert(
         sessions: List<Session>?,
-        sensorThresholds: HashMap<String, SensorThreshold>
+        sensorThresholds: Map<String, SensorThreshold>
     ) {
         sessions?.forEach { session ->
             val position = mSessionUUIDS.indexOf(session.uuid)
@@ -118,7 +117,7 @@ abstract class SessionsRecyclerAdapter<ListenerType>(
 
     protected open fun initSessionPresenter(
         session: Session,
-        sensorThresholds: HashMap<String, SensorThreshold>
+        sensorThresholds: Map<String, SensorThreshold>
     ) = SessionPresenter(
         session,
         sensorThresholds

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvc.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvc.kt
@@ -28,7 +28,7 @@ interface SessionsViewMvc : ObservableViewMvc<SessionsViewMvc.Listener> {
 
     fun showSessionsView(
         modifiedSessions: Map<SessionsObserver.ModificationType, List<Session>>,
-        sensorThresholds: HashMap<String, SensorThreshold>
+        sensorThresholds: Map<String, SensorThreshold>
     )
     fun showEmptyView()
     fun showLoaderFor(session: Session)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsViewMvcImpl.kt
@@ -82,7 +82,7 @@ abstract class SessionsViewMvcImpl<ListenerType>(
 
     override fun showSessionsView(
         modifiedSessions: Map<SessionsObserver.ModificationType, List<Session>>,
-        sensorThresholds: HashMap<String, SensorThreshold>
+        sensorThresholds: Map<String, SensorThreshold>
     ) {
         if (recyclerViewCanBeUpdated()) {
             mAdapter.bindSessions(modifiedSessions, sensorThresholds)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/following/FollowingRecyclerAdapter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/following/FollowingRecyclerAdapter.kt
@@ -29,7 +29,7 @@ open class FollowingRecyclerAdapter(
 
     override fun initSessionPresenter(
         session: Session,
-        sensorThresholds: HashMap<String, SensorThreshold>
+        sensorThresholds: Map<String, SensorThreshold>
     ): SessionPresenter {
         val expandedState = expandedCards()?.contains(session.uuid) ?: false
         return SessionPresenter(session, sensorThresholds, expanded = expandedState)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/reordering_following/ReorderingFollowingRecyclerAdapter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/reordering_following/ReorderingFollowingRecyclerAdapter.kt
@@ -71,7 +71,7 @@ class ReorderingFollowingRecyclerAdapter(
 
     override fun initSessionPresenter(
         session: Session,
-        sensorThresholds: HashMap<String, SensorThreshold>
+        sensorThresholds: Map<String, SensorThreshold>
     ): SessionPresenter {
         return SessionPresenter(session, sensorThresholds, expanded = false)
     }


### PR DESCRIPTION
This replaces the hashmaps that were used around `SessionsObserver` with concurrent hashmaps to avoid ConcurrentModificationException