### PR TITLE
Self expanding mobile active cards

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
@@ -43,6 +43,7 @@ class SessionPresenter() {
                 this.chartData = ChartData(session)
                 this.shouldHideMap = session.locationless
                 this.loading = true
+                this.expanded = true
             }
             SessionsTab.MOBILE_DORMANT -> this.shouldHideMap = session.locationless
         }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/active/MobileActiveSessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/active/MobileActiveSessionViewMvcImpl.kt
@@ -50,7 +50,6 @@ class MobileActiveSessionViewMvcImpl(
     }
 
     override fun bindExpanded() {
-        mSessionPresenter?.expanded = true
         if (mSessionPresenter?.isDisconnected() == true) {
             mDisconnectedView.show(mSessionPresenter)
 


### PR DESCRIPTION
Move setting default expanded state for mobile active sessions from bindSession() to presenter's constructor to prevent expanding of it with each new measurement