### PR TITLE
Revert mobile export patches

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/util/events/NewMeasurementEvent.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/events/NewMeasurementEvent.kt
@@ -1,6 +1,5 @@
 package pl.llp.aircasting.util.events
 
-import org.apache.commons.lang3.time.DateUtils
 import java.util.*
 
 
@@ -18,7 +17,8 @@ class NewMeasurementEvent(
     val thresholdVeryHigh: Int,
     val measuredValue: Double
 ) {
-    val creationTime = DateUtils.truncate(Date(), Calendar.SECOND).time
+    val creationTime = Date().time
 
     val deviceId get(): String? = packageName.split(':').lastOrNull()
+
 }

--- a/app/src/main/java/pl/llp/aircasting/util/helpers/location/LocationHelper.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/helpers/location/LocationHelper.kt
@@ -85,23 +85,19 @@ class LocationHelper(mContext: Context) {
     fun start() {
         locationCallback = object : LocationCallback() {
             override fun onLocationResult(locationResult: LocationResult) {
-                if (locationChanged(locationResult.lastLocation))
-                    mLastLocation = locationResult.lastLocation
+                locationResult
+                for (location in locationResult.locations) {
+                    mLastLocation = location
+                }
 
                 EventBus.getDefault()
                     .post(LocationChanged(mLastLocation?.latitude, mLastLocation?.longitude))
             }
         }
 
-        fusedLocationClient.requestLocationUpdates(
-            locationRequest,
-            locationCallback as LocationCallback, Looper.getMainLooper()
-        )
+        fusedLocationClient.requestLocationUpdates(locationRequest,
+            locationCallback as LocationCallback, Looper.getMainLooper())
 
-    }
-
-    private fun locationChanged(result: Location): Boolean {
-        return mLastLocation?.let { result.distanceTo(it) > 10f } ?: true
     }
 
     fun stop() {


### PR DESCRIPTION
This reverts commits before release that might have lead to scuffed csv file for averaged long sessions (longer than 2hrs and 9hrs). We might need the 69bc51d1d4068af73c60efc6e11b215e2e5cc390 commit later though