### PR TITLE
Save selected stream on screens

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/data/model/observers/SessionObserver.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/observers/SessionObserver.kt
@@ -46,7 +46,7 @@ abstract class SessionObserver<Type>(
 
             val measurementStream =
                 session.streams.firstOrNull { it.sensorName == selectedSensorName }
-            mSessionPresenter.selectedStream = measurementStream
+            mSessionPresenter.select(measurementStream)
 
             val sensorThresholds = mSessionsViewModel.findOrCreateSensorThresholds(session)
             mSessionPresenter.setSensorThresholds(sensorThresholds)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionPresenter.kt
@@ -10,7 +10,7 @@ import java.util.*
 
 class SessionPresenter() {
     var session: Session? = null
-    private var mSelectedStream: MeasurementStream? = defaultStream(session)
+    private var mSelectedStream: MeasurementStream? = selectStream(session)
     val selectedStream get() = mSelectedStream
     var sensorThresholds: Map<String, SensorThreshold> = hashMapOf()
     var expanded: Boolean = false
@@ -25,12 +25,10 @@ class SessionPresenter() {
     constructor(
         session: Session,
         sensorThresholds: Map<String, SensorThreshold>,
-        selectedStream: MeasurementStream? = null,
         expanded: Boolean = false,
         loading: Boolean = false
     ) : this() {
         this.session = session
-        this.mSelectedStream = defaultStream(session)
         this.expanded = expanded
         this.loading = loading
         this.sensorThresholds = sensorThresholds
@@ -77,8 +75,8 @@ class SessionPresenter() {
         return sensorThresholds[stream.sensorName]
     }
 
-    fun setStream() {
-        mSelectedStream = defaultStream(session)
+    fun updateSelectedStream() {
+        mSelectedStream = selectStream(session)
     }
 
     fun isFixed(): Boolean {
@@ -124,7 +122,7 @@ class SessionPresenter() {
     }
 
     companion object {
-        private fun defaultStream(session: Session?): MeasurementStream? {
+        private fun selectStream(session: Session?): MeasurementStream? {
             val sortedByDetailedType = session?.streamsSortedByDetailedType()
             val savedStreamDetailedType = SelectedStreams.get(session?.uuid)
 

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
@@ -172,8 +172,8 @@ abstract class SessionViewMvcImpl<ListenerType>(
     }
 
     private fun bindSelectedStream() {
-        if (mSessionPresenter?.selectedStream == null && mSessionPresenter?.allStreamsHaveLoaded() == true) {
-            mSessionPresenter?.setDefaultStream()
+        if (mSessionPresenter?.allStreamsHaveLoaded() == true) {
+            mSessionPresenter?.setStream()
         }
     }
 
@@ -281,7 +281,8 @@ abstract class SessionViewMvcImpl<ListenerType>(
     }
 
     protected fun onMeasurementStreamChanged(measurementStream: MeasurementStream) {
-        mSessionPresenter?.selectedStream = measurementStream
+        mSessionPresenter?.select(measurementStream)
+
         bindChartData()
     }
 

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionViewMvcImpl.kt
@@ -173,7 +173,7 @@ abstract class SessionViewMvcImpl<ListenerType>(
 
     private fun bindSelectedStream() {
         if (mSessionPresenter?.allStreamsHaveLoaded() == true) {
-            mSessionPresenter?.setStream()
+            mSessionPresenter?.updateSelectedStream()
         }
     }
 

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsRecyclerAdapter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsRecyclerAdapter.kt
@@ -66,6 +66,7 @@ abstract class SessionsRecyclerAdapter<ListenerType>(
             if (found(position)) {
                 val presenter = mSessionPresenters[position]
                 presenter.session = prepareSession(it, mSessionPresenters[position].expanded)
+                presenter.setStream()
                 presenter.chartData?.refresh(it)
 
                 mSessionPresenters.updateItemAt(position, presenter)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsRecyclerAdapter.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/SessionsRecyclerAdapter.kt
@@ -66,7 +66,7 @@ abstract class SessionsRecyclerAdapter<ListenerType>(
             if (found(position)) {
                 val presenter = mSessionPresenters[position]
                 presenter.session = prepareSession(it, mSessionPresenters[position].expanded)
-                presenter.setStream()
+                presenter.updateSelectedStream()
                 presenter.chartData?.refresh(it)
 
                 mSessionPresenters.updateItemAt(position, presenter)

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/search/SearchFixedBottomSheet.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/search/SearchFixedBottomSheet.kt
@@ -195,7 +195,7 @@ class SearchFixedBottomSheet : BottomSheet(), OnMapReadyCallback {
     }
 
     private fun bindSelectedStream() {
-        mSessionPresenter.setDefaultStream()
+        mSessionPresenter.setStream()
     }
 
     private fun bindSessionPresenter(
@@ -230,7 +230,7 @@ class SearchFixedBottomSheet : BottomSheet(), OnMapReadyCallback {
     }
 
     private fun onMeasurementStreamChanged(measurementStream: MeasurementStream) {
-        mSessionPresenter.selectedStream = measurementStream
+        mSessionPresenter.select(measurementStream)
         bindChartData()
     }
 

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/search/SearchFixedBottomSheet.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/search/SearchFixedBottomSheet.kt
@@ -186,7 +186,7 @@ class SearchFixedBottomSheet : BottomSheet(), OnMapReadyCallback {
             streams?.map { stream ->
                 mSensorThresholds[stream.sensorName] = getSensorThresholds(stream)
 
-                bindSessionPresenter(session, mSensorThresholds, stream)
+                bindSessionPresenter(session, mSensorThresholds)
                 bindSelectedStream()
                 bindChartData()
                 bindSession()
@@ -195,15 +195,14 @@ class SearchFixedBottomSheet : BottomSheet(), OnMapReadyCallback {
     }
 
     private fun bindSelectedStream() {
-        mSessionPresenter.setStream()
+        mSessionPresenter.updateSelectedStream()
     }
 
     private fun bindSessionPresenter(
         session: Session,
-        mSensorThresholds: HashMap<String, SensorThreshold>,
-        stream: MeasurementStream
+        mSensorThresholds: HashMap<String, SensorThreshold>
     ) {
-        mSessionPresenter = SessionPresenter(session, mSensorThresholds, stream)
+        mSessionPresenter = SessionPresenter(session, mSensorThresholds)
     }
 
     private fun bindChartData() {

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/SessionDetailsViewMvcImpl.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/SessionDetailsViewMvcImpl.kt
@@ -161,7 +161,7 @@ abstract class SessionDetailsViewMvcImpl(
     }
 
     protected open fun onMeasurementStreamChanged(measurementStream: MeasurementStream) {
-        mSessionPresenter?.selectedStream = measurementStream
+        mSessionPresenter?.select(measurementStream)
         mStatisticsContainer?.refresh(mSessionPresenter)
         bindSession(mSessionPresenter)
     }

--- a/app/src/main/java/pl/llp/aircasting/util/SelectedStreams.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/SelectedStreams.kt
@@ -1,0 +1,26 @@
+package pl.llp.aircasting.util
+
+import org.greenrobot.eventbus.EventBus
+import pl.llp.aircasting.data.model.SensorName
+import pl.llp.aircasting.ui.view.screens.dashboard.SessionPresenter
+import pl.llp.aircasting.util.events.StreamSelectedEvent
+import java.util.concurrent.ConcurrentHashMap
+
+object SelectedStreams {
+    private val selectedStreams: MutableMap<String, SensorName> = ConcurrentHashMap()
+
+    fun save(presenter: SessionPresenter?) {
+        val uuid = presenter?.session?.uuid ?: return
+        val detailedType = presenter.selectedStream?.detailedType ?: return
+        val sensorName = SensorName.fromString(detailedType) ?: return
+
+        selectedStreams[uuid] = sensorName
+        EventBus.getDefault().postSticky(StreamSelectedEvent(presenter.session))
+    }
+
+    fun get(uuid: String?): String? {
+        if (uuid == null) return null
+
+        return selectedStreams[uuid]?.detailedType
+    }
+}

--- a/app/src/main/java/pl/llp/aircasting/util/events/StreamSelectedEvent.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/events/StreamSelectedEvent.kt
@@ -1,0 +1,7 @@
+package pl.llp.aircasting.util.events
+
+import pl.llp.aircasting.data.model.Session
+
+class StreamSelectedEvent(private val mSession: Session?) {
+    val session get() = mSession
+}


### PR DESCRIPTION
This saves selected streams of presenters to Object while the app is running. The selected streams get synced and selected across the session's appearances (on Graph, Map, Cards, S&F)