### PR TITLE
Incorrect notes photo order on sign out

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/data/api/services/SessionsSyncService.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/api/services/SessionsSyncService.kt
@@ -171,10 +171,7 @@ class SessionsSyncService private constructor(
         val mNotes = sessionID?.let { noteRepository.getNotesForSessionWithId(it) }
 
         val encodedPhotos = mNotes?.filterNotNull()?.map { note ->
-            if (note.photo_location == null)
-                null
-            else
-                encodeToBase64(note.photo_location.toUri())
+            encodeToBase64(note.photo_location?.toUri())
         }
         return encodedPhotos
     }

--- a/app/src/main/java/pl/llp/aircasting/data/local/entity/notes.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/local/entity/notes.kt
@@ -1,6 +1,5 @@
 package pl.llp.aircasting.data.local.entity
 
-import android.net.Uri
 import androidx.room.*
 import pl.llp.aircasting.data.model.Note
 import java.util.*

--- a/app/src/main/java/pl/llp/aircasting/util/NoteResponseParser.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/NoteResponseParser.kt
@@ -16,7 +16,7 @@ class NoteResponseParser(private val errorHandler: ErrorHandler) {
                 noteResponse.latitude,
                 noteResponse.longitude,
                 noteResponse.number,
-                ApiConstants.baseUrl + noteResponse.photo
+                parsePhotoLocation(noteResponse.photo)
             )
     }
 
@@ -27,5 +27,11 @@ class NoteResponseParser(private val errorHandler: ErrorHandler) {
             errorHandler.handle(ParseDateError(parseException))
             Date()
         }
+    }
+
+    private fun parsePhotoLocation(photoLocationOnServer: String?): String? {
+        photoLocationOnServer ?: return null
+
+        return ApiConstants.baseUrl + photoLocationOnServer
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/util/extensions/extensions.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/extensions/extensions.kt
@@ -120,12 +120,14 @@ fun backToUIThread(scope: CoroutineScope, uiBlock: () -> Unit) {
 }
 
 fun encodeToBase64(filepath: Uri?): String? {
+    filepath ?: return ""
+
     return try {
-        val inputStream = FileInputStream(filepath?.path)
+        val inputStream = FileInputStream(filepath.path)
         val bytes = ByteArray(inputStream.available())
         inputStream.read(bytes)
         encodeToString(bytes, DEFAULT)
     } catch (e: Exception) {
-        null
+        ""
     }
 }


### PR DESCRIPTION
This resolves getting incorrect order of notes from backend in situation when we have notes with photos and without. The solution was to send empty string in the place of photo path when we don't have a photo attached to note.