### PR TITLE
Fix/mobile sync

### DIFF
--- a/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
@@ -2,6 +2,7 @@ package pl.llp.aircasting.data.model
 
 import pl.llp.aircasting.data.api.response.search.SessionInRegionResponse
 import pl.llp.aircasting.data.local.entity.CompleteSessionDBObject
+import pl.llp.aircasting.data.local.entity.LatLng
 import pl.llp.aircasting.data.local.entity.SessionDBObject
 import pl.llp.aircasting.data.local.entity.SessionWithNotesDBObject
 import pl.llp.aircasting.data.local.entity.SessionWithStreamsAndLastMeasurementsDBObject
@@ -214,9 +215,11 @@ open class Session(
         }
 
         override fun equals(other: Any?): Boolean {
-            if (other == null || other !is Location) return false
-
-            return latitude == other.latitude && longitude == other.longitude
+            return when (other){
+                is Location -> latitude == other.latitude && longitude == other.longitude
+                is LatLng -> latitude == other.latitude && longitude == other.longitude
+                else -> false
+            }
         }
 
         override fun hashCode(): Int {

--- a/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
@@ -215,7 +215,7 @@ open class Session(
         }
 
         override fun equals(other: Any?): Boolean {
-            return when (other){
+            return when (other) {
                 is Location -> latitude == other.latitude && longitude == other.longitude
                 is LatLng -> latitude == other.latitude && longitude == other.longitude
                 else -> false

--- a/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
+++ b/app/src/main/java/pl/llp/aircasting/data/model/Session.kt
@@ -1,8 +1,8 @@
 package pl.llp.aircasting.data.model
 
+import com.google.android.gms.maps.model.LatLng
 import pl.llp.aircasting.data.api.response.search.SessionInRegionResponse
 import pl.llp.aircasting.data.local.entity.CompleteSessionDBObject
-import pl.llp.aircasting.data.local.entity.LatLng
 import pl.llp.aircasting.data.local.entity.SessionDBObject
 import pl.llp.aircasting.data.local.entity.SessionWithNotesDBObject
 import pl.llp.aircasting.data.local.entity.SessionWithStreamsAndLastMeasurementsDBObject
@@ -215,11 +215,9 @@ open class Session(
         }
 
         override fun equals(other: Any?): Boolean {
-            return when (other) {
-                is Location -> latitude == other.latitude && longitude == other.longitude
-                is LatLng -> latitude == other.latitude && longitude == other.longitude
-                else -> false
-            }
+            if (other == null || other !is Location) return false
+
+            return latitude == other.latitude && longitude == other.longitude
         }
 
         override fun hashCode(): Int {
@@ -231,6 +229,8 @@ open class Session(
         override fun toString(): String {
             return "Location(latitude=$latitude, longitude=$longitude)"
         }
+
+        fun toLatLng() = LatLng(latitude, longitude)
     }
 
     val type get() = mType

--- a/app/src/main/java/pl/llp/aircasting/di/UserDependentComponent.kt
+++ b/app/src/main/java/pl/llp/aircasting/di/UserDependentComponent.kt
@@ -32,6 +32,7 @@ import pl.llp.aircasting.util.helpers.sensor.services.AirBeamClearCardService
 import pl.llp.aircasting.util.helpers.sensor.services.AirBeamRecordSessionService
 import pl.llp.aircasting.util.helpers.sensor.services.AirBeamSyncService
 import pl.llp.aircasting.util.helpers.sensor.microphone.MicrophoneService
+import pl.llp.aircasting.util.helpers.sensor.services.AirBeamReconnectSessionService
 import pl.llp.aircasting.util.helpers.sensor.services.BatteryLevelService
 import javax.inject.Scope
 
@@ -104,6 +105,7 @@ interface UserDependentComponent {
     fun inject(activity: AirBeamRecordSessionService)
     fun inject(activity: AirBeamSyncService)
     fun inject(activity: AirBeamClearCardService)
+    fun inject(activity: AirBeamReconnectSessionService)
 }
 
 @Scope

--- a/app/src/main/java/pl/llp/aircasting/di/modules/FlowModule.kt
+++ b/app/src/main/java/pl/llp/aircasting/di/modules/FlowModule.kt
@@ -19,6 +19,12 @@ class FlowModule {
     @AirbeamConnectionStatusFlow
     @UserSessionScope
     fun provideAirbeamConnectionStatusFlow(): MutableStateFlow<AirbeamConnectionStatus?> = MutableStateFlow(null)
+
+    @Provides
+    @SyncActiveFlow
+    @UserSessionScope
+    fun provideSyncActiveFlow(): MutableSharedFlow<Boolean> = MutableSharedFlow()
+
 }
 
 @Retention(AnnotationRetention.BINARY)
@@ -28,3 +34,7 @@ annotation class BatteryLevelFlow
 @Retention(AnnotationRetention.BINARY)
 @Qualifier
 annotation class AirbeamConnectionStatusFlow
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class SyncActiveFlow

--- a/app/src/main/java/pl/llp/aircasting/di/modules/FlowModule.kt
+++ b/app/src/main/java/pl/llp/aircasting/di/modules/FlowModule.kt
@@ -4,12 +4,14 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import pl.llp.aircasting.data.model.AirbeamConnectionStatus
 import pl.llp.aircasting.di.UserSessionScope
 import javax.inject.Qualifier
 
 @Module
 class FlowModule {
+    private val syncActiveFlow = MutableSharedFlow<Boolean>()
     @Provides
     @BatteryLevelFlow
     @UserSessionScope
@@ -23,7 +25,12 @@ class FlowModule {
     @Provides
     @SyncActiveFlow
     @UserSessionScope
-    fun provideSyncActiveFlow(): MutableSharedFlow<Boolean> = MutableSharedFlow()
+    fun provideMutableSyncActiveFlow() = syncActiveFlow
+
+    @Provides
+    @SyncActiveFlow
+    @UserSessionScope
+    fun provideSyncActiveFlow() = syncActiveFlow.asSharedFlow()
 
 }
 

--- a/app/src/main/java/pl/llp/aircasting/di/modules/SensorsModule.kt
+++ b/app/src/main/java/pl/llp/aircasting/di/modules/SensorsModule.kt
@@ -3,8 +3,8 @@ package pl.llp.aircasting.di.modules
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import pl.llp.aircasting.AircastingApplication
 import pl.llp.aircasting.data.api.services.FixedSessionUploadService
 import pl.llp.aircasting.data.api.services.SessionsSyncService
@@ -53,7 +53,7 @@ open class SensorsModule {
         airBeamDiscoveryService: AirBeamDiscoveryService,
         @IoCoroutineScope coroutineScope: CoroutineScope,
         @AirbeamConnectionStatusFlow connectionStatusFlow: MutableStateFlow<AirbeamConnectionStatus>,
-        @SyncActiveFlow syncActiveFlow: MutableSharedFlow<Boolean>
+        @SyncActiveFlow syncActiveFlow: SharedFlow<Boolean>
     ): AirBeamReconnector =
         AirBeamReconnector(
             application,

--- a/app/src/main/java/pl/llp/aircasting/di/modules/SensorsModule.kt
+++ b/app/src/main/java/pl/llp/aircasting/di/modules/SensorsModule.kt
@@ -3,6 +3,7 @@ package pl.llp.aircasting.di.modules
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import pl.llp.aircasting.AircastingApplication
 import pl.llp.aircasting.data.api.services.FixedSessionUploadService
@@ -52,8 +53,15 @@ open class SensorsModule {
         airBeamDiscoveryService: AirBeamDiscoveryService,
         @IoCoroutineScope coroutineScope: CoroutineScope,
         @AirbeamConnectionStatusFlow connectionStatusFlow: MutableStateFlow<AirbeamConnectionStatus>,
+        @SyncActiveFlow syncActiveFlow: MutableSharedFlow<Boolean>
     ): AirBeamReconnector =
-        AirBeamReconnector(application, sessionsRepository, airBeamDiscoveryService, coroutineScope, connectionStatusFlow = connectionStatusFlow)
+        AirBeamReconnector(
+            application,
+            sessionsRepository,
+            airBeamDiscoveryService,
+            coroutineScope,
+            connectionStatusFlow = connectionStatusFlow,
+            syncStatusFlow = syncActiveFlow)
 
     @Provides
     @UserSessionScope

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/active/FinishAndSyncSessionConfirmationDialog.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/active/FinishAndSyncSessionConfirmationDialog.kt
@@ -37,7 +37,7 @@ class FinishAndSyncSessionConfirmationDialog(
     }
 
     override fun finishSessionConfirmed() {
-        onFinishAndSyncMobileSessionConfirmed(mSession)
+        onFinishAndSyncMobileSessionConfirmed()
         dismiss()
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/active/FinishMobileSessionListener.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/dashboard/active/FinishMobileSessionListener.kt
@@ -30,9 +30,7 @@ interface FinishMobileSessionListener {
             rootActivity.finish()
     }
 
-    fun onFinishAndSyncMobileSessionConfirmed(session: Session) {
-        val event = StopRecordingEvent(session.uuid)
-        EventBus.getDefault().post(event)
+    fun onFinishAndSyncMobileSessionConfirmed() {
         SyncActivity.start(rootActivity)
     }
 }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/map/MapContainer.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/map/MapContainer.kt
@@ -170,6 +170,12 @@ class MapContainer(rootView: View?, context: Context, supportFragmentManager: Fr
 
         var latestPoint: LatLng? = null
         var latestColor: Int? = null
+        val isFixed = mSessionPresenter?.isFixed() ?: false
+
+        if (isFixed) {
+            val measurement = mMeasurements.first { it.latitude != null && it.longitude != null }
+            latestPoint = LatLng(measurement.latitude!!, measurement.longitude!!)
+        }
 
         for (measurement in mMeasurements) {
             latestColor = MeasurementColor.forMap(
@@ -177,9 +183,12 @@ class MapContainer(rootView: View?, context: Context, supportFragmentManager: Fr
                 measurement,
                 mSessionPresenter?.selectedSensorThreshold()
             )
-            val measurementLocation = LatLng(measurement.latitude!!, measurement.longitude!!)
-            if (!Session.Location.FAKE_LOCATION.equals(measurementLocation)) {
-                latestPoint = measurementLocation
+            if (!isFixed) {
+                val measurementLocation = LatLng(measurement.latitude!!, measurement.longitude!!)
+
+                if (!Session.Location.FAKE_LOCATION.equals(measurementLocation)) {
+                    latestPoint = measurementLocation
+                }
             }
 
             latestPoint?.let { mMeasurementPoints.add(it) }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/map/MapContainer.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/map/MapContainer.kt
@@ -186,7 +186,7 @@ class MapContainer(rootView: View?, context: Context, supportFragmentManager: Fr
             if (!isFixed) {
                 val measurementLocation = LatLng(measurement.latitude!!, measurement.longitude!!)
 
-                if (!Session.Location.FAKE_LOCATION.equals(measurementLocation)) {
+                if (Session.Location.FAKE_LOCATION.toLatLng() != measurementLocation) {
                     latestPoint = measurementLocation
                 }
             }

--- a/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/map/MapContainer.kt
+++ b/app/src/main/java/pl/llp/aircasting/ui/view/screens/session_view/map/MapContainer.kt
@@ -171,16 +171,18 @@ class MapContainer(rootView: View?, context: Context, supportFragmentManager: Fr
         var latestPoint: LatLng? = null
         var latestColor: Int? = null
 
-        var i = 0
         for (measurement in mMeasurements) {
             latestColor = MeasurementColor.forMap(
                 mContext,
                 measurement,
                 mSessionPresenter?.selectedSensorThreshold()
             )
-            latestPoint = LatLng(measurement.latitude!!, measurement.longitude!!)
-            mMeasurementPoints.add(latestPoint)
-            i += 1
+            val measurementLocation = LatLng(measurement.latitude!!, measurement.longitude!!)
+            if (!Session.Location.FAKE_LOCATION.equals(measurementLocation)) {
+                latestPoint = measurementLocation
+            }
+
+            latestPoint?.let { mMeasurementPoints.add(it) }
         }
         mMeasurementsLineOptions.addAll(mMeasurementPoints)
         mMeasurementsLine = mMap?.addPolyline(mMeasurementsLineOptions)

--- a/app/src/main/java/pl/llp/aircasting/util/helpers/sensor/common/connector/AirBeamReconnector.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/helpers/sensor/common/connector/AirBeamReconnector.kt
@@ -3,8 +3,8 @@ package pl.llp.aircasting.util.helpers.sensor.common.connector
 import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import pl.llp.aircasting.data.api.util.LogKeys.bluetoothReconnection
@@ -29,7 +29,7 @@ class AirBeamReconnector(
     private val sessionUuidByStandaloneMode: MutableMap<String, Boolean> = ConcurrentHashMap(),
     private val connectionStatusFlow: MutableStateFlow<AirbeamConnectionStatus>,
     @SyncActiveFlow
-    private val syncStatusFlow: MutableSharedFlow<Boolean>,
+    private val syncStatusFlow: SharedFlow<Boolean>,
 ) {
     private var mSession: Session? = null
     private var mErrorCallback: (() -> Unit)? = null

--- a/app/src/main/java/pl/llp/aircasting/util/helpers/sensor/services/AirBeamReconnectSessionService.kt
+++ b/app/src/main/java/pl/llp/aircasting/util/helpers/sensor/services/AirBeamReconnectSessionService.kt
@@ -6,7 +6,7 @@ import android.os.Parcelable
 import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import pl.llp.aircasting.AircastingApplication
@@ -21,7 +21,7 @@ class AirBeamReconnectSessionService: AirBeamRecordSessionService() {
 
     @Inject
     @SyncActiveFlow
-    lateinit var syncActiveFlow: MutableSharedFlow<Boolean>
+    lateinit var syncActiveFlow: SharedFlow<Boolean>
 
     @Inject
     @MainScope

--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -2,8 +2,8 @@ object AppConfig {
     const val compileSdk = 33
     const val minSdk = 21
     const val targetSdk = 33
-    const val versionCode = 256
-    const val versionName = "3.0.6-exp"
+    const val versionCode = 257
+    const val versionName = "3.0.7-exp"
     const val buildToolsVersion = "30.0.3"
 
     const val androidTestInstrumentation = "pl.llp.aircasting.helpers.EspressoRunner"


### PR DESCRIPTION
Added flow with boolean to stop reconnection service when user starts sync while AB is in the standalone mode which could cause session to go into "recording" state after sync.

after ABM restarts during fixed session, we receive fake location, to not display it only the location with first coordinates is used